### PR TITLE
Fix clock tests for intro.js

### DIFF
--- a/2.0/src/introduction.js
+++ b/2.0/src/introduction.js
@@ -735,14 +735,14 @@ describe("Manually ticking the Jasmine Clock", function() {
 */
 describe("Single spec mock clock", function() {
   it("can install and uninstall", function() {
-    clock.useMock(function() {
+    jasmine.clock.useMock(function() {
       setTimeout(function() {
         timerCallback();
       }, 100);
 
       expect(timerCallback).not.toHaveBeenCalled();
 
-      clock.tick(101);
+      jasmine.clock.tick(101);
 
       expect(timerCallback).toHaveBeenCalled();
     });


### PR DESCRIPTION
The build was failing, so it seemed prudent to fix this spec. 

@slackersoft claimed this was the result of a bad merge.
