### PR TITLE
Fix sizing of jasmine/pivotal SVGs in firefox by changing flexboxy styles to absolute positioning

### DIFF
--- a/2.0/ajax.html
+++ b/2.0/ajax.html
@@ -7,11 +7,13 @@
   <link rel="stylesheet" href="css/docco.css"/>
   <link rel="stylesheet" href="css/jasmine_docco.css"/>
   <link rel="stylesheet" href="lib/jasmine.css"/>
+  
   <script src="lib/jasmine.js"></script>
   <script src="lib/jasmine-html.js"></script>
   <script src="lib/boot.js"></script>
   <script src="src/support/mock-ajax.js"></script>
   <script src="src/ajax.js"></script>
+  
   <link rel="icon" href="images/jasmine.ico" sizes="16x16">
   <link rel="icon" href="images/jasmine_32x32.ico" sizes="32x32">
 </head>
@@ -32,16 +34,15 @@
     </div>
   </div>
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>

--- a/2.0/boot.html
+++ b/2.0/boot.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/docco.css"/>
   <link rel="stylesheet" href="css/jasmine_docco.css"/>
   <link rel="stylesheet" href="lib/jasmine.css"/>
+  
   <link rel="icon" href="images/jasmine.ico" sizes="16x16">
   <link rel="icon" href="images/jasmine_32x32.ico" sizes="32x32">
 </head>
@@ -27,16 +28,15 @@
     </div>
   </div>
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>

--- a/2.0/css/jasmine_docco.css
+++ b/2.0/css/jasmine_docco.css
@@ -13,48 +13,32 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 700;
 }
 
-.title-banner {
-  padding: 12px;
-  display: -moz-box;
-  display: -webkit-box;
-  display: -ms-box;
-  display: box;
-  -moz-box-orient: horizontal;
-  -webkit-box-orient: horizontal;
-  -ms-box-orient: horizontal;
-  box-orient: horizontal;
-  -moz-box-pack: start;
-  -webkit-box-pack: start;
-  -ms-box-pack: start;
-  box-pack: start;
+#jump_to {
+  z-index: 100;
 }
 
-.title-banner a,
-.title-banner span,
-.title-banner div {
-  display: -moz-box;
-  display: -webkit-box;
-  display: -ms-box;
-  display: box;
-  -moz-box-orient: vertical;
-  -webkit-box-orient: vertical;
-  -ms-box-orient: vertical;
-  box-orient: vertical;
-  -moz-box-pack: center;
-  -webkit-box-pack: center;
-  -ms-box-pack: center;
-  box-pack: center;
+.title-banner {
+  position: relative;
+  height: 105px;
+}
+
+.title-banner .jasmine-logo {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+}
+
+.title-banner .pivotal-logo {
+  position: absolute;
+  top: 23px;
+  right: 12px;
+  display: table;
 }
 
 .powered {
   padding: 7px 12px 12px;
-}
-
-.spacer {
-  -moz-box-flex: 1;
-  -webkit-box-flex: 1;
-  -ms-box-flex: 1;
-  box-flex: 1;
+  display: table-cell;
+  vertical-align: middle;
 }
 
 strong {

--- a/2.0/custom_equality.html
+++ b/2.0/custom_equality.html
@@ -7,11 +7,13 @@
   <link rel="stylesheet" href="css/docco.css"/>
   <link rel="stylesheet" href="css/jasmine_docco.css"/>
   <link rel="stylesheet" href="lib/jasmine.css"/>
+  
   <script src="lib/jasmine.js"></script>
   <script src="lib/jasmine-html.js"></script>
   <script src="lib/boot.js"></script>
   <script src="src/support/mock-ajax.js"></script>
   <script src="src/custom_equality.js"></script>
+  
   <link rel="icon" href="images/jasmine.ico" sizes="16x16">
   <link rel="icon" href="images/jasmine_32x32.ico" sizes="32x32">
 </head>
@@ -32,16 +34,15 @@
     </div>
   </div>
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>

--- a/2.0/custom_matcher.html
+++ b/2.0/custom_matcher.html
@@ -7,11 +7,13 @@
   <link rel="stylesheet" href="css/docco.css"/>
   <link rel="stylesheet" href="css/jasmine_docco.css"/>
   <link rel="stylesheet" href="lib/jasmine.css"/>
+  
   <script src="lib/jasmine.js"></script>
   <script src="lib/jasmine-html.js"></script>
   <script src="lib/boot.js"></script>
   <script src="src/support/mock-ajax.js"></script>
   <script src="src/custom_matcher.js"></script>
+  
   <link rel="icon" href="images/jasmine.ico" sizes="16x16">
   <link rel="icon" href="images/jasmine_32x32.ico" sizes="32x32">
 </head>
@@ -32,16 +34,15 @@
     </div>
   </div>
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>

--- a/2.0/introduction.html
+++ b/2.0/introduction.html
@@ -7,11 +7,13 @@
   <link rel="stylesheet" href="css/docco.css"/>
   <link rel="stylesheet" href="css/jasmine_docco.css"/>
   <link rel="stylesheet" href="lib/jasmine.css"/>
+  
   <script src="lib/jasmine.js"></script>
   <script src="lib/jasmine-html.js"></script>
   <script src="lib/boot.js"></script>
   <script src="src/support/mock-ajax.js"></script>
   <script src="src/introduction.js"></script>
+  
   <link rel="icon" href="images/jasmine.ico" sizes="16x16">
   <link rel="icon" href="images/jasmine_32x32.ico" sizes="32x32">
 </head>
@@ -32,16 +34,15 @@
     </div>
   </div>
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>

--- a/2.0/ruby_gem.html
+++ b/2.0/ruby_gem.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/docco.css"/>
   <link rel="stylesheet" href="css/jasmine_docco.css"/>
   <link rel="stylesheet" href="lib/jasmine.css"/>
+  
   <link rel="icon" href="images/jasmine.ico" sizes="16x16">
   <link rel="icon" href="images/jasmine_32x32.ico" sizes="32x32">
 </head>
@@ -27,16 +28,15 @@
     </div>
   </div>
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>

--- a/src/layout.erb
+++ b/src/layout.erb
@@ -33,16 +33,15 @@
   </div>
   {{/sources?}}
   <div class="title-banner">
-    <a href="http://github.com/pivotal/jasmine">
+    <a class='jasmine-logo' href="http://github.com/pivotal/jasmine">
       <img src="images/jasmine-horizontal.svg" width="273px"/>
     </a>
-    <span class="spacer"></span>
-    <div class="powered">
-      <span>Powered by</span>
+    <div class='pivotal-logo'>
+      <span class='powered'>Powered by</span>
+      <a href="http://pivotallabs.com/" target="_blank">
+        <img src="images/pivotal_logo.svg" width="150px"/>
+      </a>
     </div>
-    <a href="http://pivotallabs.com/" target="_blank">
-      <img src="images/pivotal_logo.svg" width="150px"/>
-    </a>
   </div>
   <table cellspacing="0" cellpadding="0">
     <thead>


### PR DESCRIPTION
:warning: Controversial CSS changes ahead :warning:

Since @sheelc and @tjarratt changed the Jasmine/Pivotal logos to SVG in e178fcd7ba9b9bafa061db6444cebd96904fc2fe, they look like this in my Firefox (OSX):

![screen shot 2013-11-14 at 10 12 44 pm](https://f.cloud.github.com/assets/1041691/1548163/713fcfd0-4dbd-11e3-9d64-d5a863950f16.png)

I traced the problem down to the `-moz-box` style on the header elements, which is [apparently the 'old' kind of flexbox](http://css-tricks.com/old-flexbox-and-new-flexbox/). The pixel sizes on the SVGs don't get respected at all in Firefox while that rule is active. (Though I can't find anything in the Firefox bug tracker to prove that this is known to be the case. There could be some other property that, when toggled, fixes everything.)

One possible fix is to upgrade it to the 'new' flexbox, which might understand the SVG better, but then it might look even worse in older browsers. So here I propose this patch that changes the code to use sophisticated CSS `position: absolute` technology.

The only downside of this (other than that the titlebar now has to declare its height) is that when you squish the window down really small it looks like this:

![screen shot 2013-11-14 at 10 26 09 pm](https://f.cloud.github.com/assets/1041691/1548200/d4d95632-4dbe-11e3-90b0-60059ab5e304.png)

But nobody should be setting their viewport that small anyway, unless they're on a phone. Where http://jasmine.github.io/2.0/introduction.html currently looks like this:

![screen shot 2013-11-14 at 10 32 30 pm](https://f.cloud.github.com/assets/1041691/1548224/bbe6a336-4dbf-11e3-931c-ec8f78432ec5.png)

So I don't think it's a big deal.
