### PR TITLE
Fixed link to custom matchers

### DIFF
--- a/2.0/introduction.html
+++ b/2.0/introduction.html
@@ -164,7 +164,7 @@ An expectation in Jasmine is an assertion that is either true or false. A spec w
         <h3>Included Matchers</h3>
 
 <p>Jasmine has a rich set of matchers included. Each is used here &ndash; all expectations and specs pass.
-There is also the ability to write <a href="https://github.com/pivotal/jasmine/wiki/Matchers">custom matchers</a> for when a project&rsquo;s domain calls for specific assertions that are not included below.</p>
+There is also the ability to write <a href="custom_matcher.html">custom matchers</a> for when a project&rsquo;s domain calls for specific assertions that are not included below.</p>
       </td>
       <td class="code">
         <div class="highlight">


### PR DESCRIPTION
In the "Included Matchers" section is a link to the custom matchers. It points to the outdated wiki page. I fixed it so that i points to the custom_matchers.js
