### PR TITLE
clarify beforeEach/afterEach doc language

### DIFF
--- a/2.0/introduction.html
+++ b/2.0/introduction.html
@@ -324,7 +324,7 @@ There is also the ability to write <a href="custom_matcher.html">custom matchers
         </div>
         <h3>Setup and Teardown</h3>
 
-<p>To help a test suite DRY up any duplicated setup and teardown code, Jasmine provides the global <code>beforeEach</code> and <code>afterEach</code> functions. As the name implies the <code>beforeEach</code> function is called once before each spec in the <code>describe</code> is run and the <code>afterEach</code> function is called once after each spec.
+<p>To help a test suite DRY up any duplicated setup and teardown code, Jasmine provides the global <code>beforeEach</code> and <code>afterEach</code> functions. As the name implies, the <code>beforeEach</code> function is called once before each spec in the <code>describe</code> is run, and the <code>afterEach</code> function is called once after each spec.
 Here is the same set of specs written a little differently. The variable under test is defined at the top-level scope &mdash; the <code>describe</code> block &mdash;  and initialization code is moved into a <code>beforeEach</code> function. The <code>afterEach</code> function resets the variable before continuing.</p>
       </td>
       <td class="code">


### PR DESCRIPTION
As written, the clauses in this sentence are hard to parse. These two commas help clarify.
