### PR TITLE
Center index page and remove horizontal scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
     <style type="text/css">
         body {
             background: #eee;
-            padding: 12px;
+            margin: 0;
+            padding: 20px 0;
             display: -webkit-box;
             display: -ms-box;
             display: box;


### PR DESCRIPTION
The body's non-zero left/right padding (and a non-specified margin,
which most browsers will default to something non-zero) with
`width: 100%` causes the index page to:
- Have a permanent horizontal scrollbar -- the actual computed width
  is greater than the size of the browser window
- Appear slightly off-center on page load -- pushed to the right by the
  left margin and padding

This commit leaves the effective body top and bottom spacing as-is (
though it replaces the implicit non-zero margin with zero margin and
padding to make up for what browsers usually set as an implicit body
margin), but removes the left/right padding and margin.

Tested on OS X Chrome/Safari/Firefox and iPhone Mobile Safari.
