### PR TITLE
Add docs for `toThrowError` matcher

### DIFF
--- a/2.0/introduction.html
+++ b/2.0/introduction.html
@@ -284,6 +284,17 @@ There is also the ability to write <a href="custom_matcher.html">custom matchers
     <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toThrow</span><span class="p">();</span>
     <span class="nx">expect</span><span class="p">(</span><span class="nx">bar</span><span class="p">).</span><span class="nx">toThrow</span><span class="p">();</span>
   <span class="p">});</span>
+
+  <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;The &#39;toThrowError&#39; matcher is for testing a specific thrown exception&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+    <span class="kd">var</span> <span class="nx">foo</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+      <span class="k">throw</span> <span class="k">new</span> <span class="nx">TypeError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="p">};</span>
+
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="sr">/bar/</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">,</span> <span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+  <span class="p">});</span>
 <span class="p">});</span></pre>
         </div>
       </td>

--- a/2.0/ruby_gem.html
+++ b/2.0/ruby_gem.html
@@ -259,7 +259,7 @@ The command line tool will also modify your Rakefile to load the jasmine tasks</
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -274,7 +274,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
 <span class="k">end</span></pre>
         </div>
       </td>
@@ -305,7 +305,7 @@ For an example of how to add your custom formatter see the <a href="#section-Con
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Formatter</span></pre>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -383,7 +383,7 @@ For an example of how to add your custom runner see the <a href="#section-Config
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Runner</span>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span>
   <span class="k">def</span> <span class="nf">initialize</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">jasmine_server_url</span><span class="p">,</span> <span class="n">result_batch_size</span><span class="p">)</span></pre>
         </div>
       </td>

--- a/2.0/src/introduction.js
+++ b/2.0/src/introduction.js
@@ -185,6 +185,17 @@ describe("Included matchers:", function() {
     expect(foo).not.toThrow();
     expect(bar).toThrow();
   });
+
+  it("The 'toThrowError' matcher is for testing a specific thrown exception", function() {
+    var foo = function() {
+      throw new TypeError("foo bar baz");
+    };
+
+    expect(foo).toThrowError("foo bar baz");
+    expect(foo).toThrowError(/bar/);
+    expect(foo).toThrowError(TypeError);
+    expect(foo).toThrowError(TypeError, "foo bar baz");
+  });
 });
 
 /**

--- a/2.1/introduction.html
+++ b/2.1/introduction.html
@@ -287,6 +287,17 @@ There is also the ability to write <a href="custom_matcher.html">custom matchers
     <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toThrow</span><span class="p">();</span>
     <span class="nx">expect</span><span class="p">(</span><span class="nx">bar</span><span class="p">).</span><span class="nx">toThrow</span><span class="p">();</span>
   <span class="p">});</span>
+
+  <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;The &#39;toThrowError&#39; matcher is for testing a specific thrown exception&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+    <span class="kd">var</span> <span class="nx">foo</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+      <span class="k">throw</span> <span class="k">new</span> <span class="nx">TypeError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="p">};</span>
+
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="sr">/bar/</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">,</span> <span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+  <span class="p">});</span>
 <span class="p">});</span></pre>
         </div>
       </td>

--- a/2.1/ruby_gem.html
+++ b/2.1/ruby_gem.html
@@ -262,7 +262,7 @@ The command line tool will also modify your Rakefile to load the jasmine tasks</
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -277,7 +277,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
 <span class="k">end</span></pre>
         </div>
       </td>
@@ -295,7 +295,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="n">show_console_log</span><span class="p">:</span> <span class="kp">true</span></pre>
+          <pre><span class="ss">show_console_log</span><span class="p">:</span> <span class="kp">true</span></pre>
         </div>
       </td>
     </tr>
@@ -308,7 +308,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="n">phantom_config_script</span><span class="p">:</span> <span class="s1">&#39;relative/path/from/project/root.js&#39;</span></pre>
+          <pre><span class="ss">phantom_config_script</span><span class="p">:</span> <span class="s1">&#39;relative/path/from/project/root.js&#39;</span></pre>
         </div>
       </td>
     </tr>
@@ -356,7 +356,7 @@ For an example of how to add your custom formatter see the <a href="#section-Con
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Formatter</span></pre>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -434,7 +434,7 @@ For an example of how to add your custom runner see the <a href="#section-Config
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Runner</span>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span>
   <span class="k">def</span> <span class="nf">initialize</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">jasmine_server_url</span><span class="p">,</span> <span class="n">result_batch_size</span><span class="p">)</span></pre>
         </div>
       </td>

--- a/2.1/src/introduction.js
+++ b/2.1/src/introduction.js
@@ -185,6 +185,17 @@ describe("Included matchers:", function() {
     expect(foo).not.toThrow();
     expect(bar).toThrow();
   });
+
+  it("The 'toThrowError' matcher is for testing a specific thrown exception", function() {
+    var foo = function() {
+      throw new TypeError("foo bar baz");
+    };
+
+    expect(foo).toThrowError("foo bar baz");
+    expect(foo).toThrowError(/bar/);
+    expect(foo).toThrowError(TypeError);
+    expect(foo).toThrowError(TypeError, "foo bar baz");
+  });
 });
 
 /**

--- a/2.2/introduction.html
+++ b/2.2/introduction.html
@@ -287,6 +287,17 @@ There is also the ability to write <a href="custom_matcher.html">custom matchers
     <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toThrow</span><span class="p">();</span>
     <span class="nx">expect</span><span class="p">(</span><span class="nx">bar</span><span class="p">).</span><span class="nx">toThrow</span><span class="p">();</span>
   <span class="p">});</span>
+
+  <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;The &#39;toThrowError&#39; matcher is for testing a specific thrown exception&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+    <span class="kd">var</span> <span class="nx">foo</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+      <span class="k">throw</span> <span class="k">new</span> <span class="nx">TypeError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="p">};</span>
+
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="sr">/bar/</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">,</span> <span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+  <span class="p">});</span>
 <span class="p">});</span></pre>
         </div>
       </td>

--- a/2.2/ruby_gem.html
+++ b/2.2/ruby_gem.html
@@ -262,7 +262,7 @@ The command line tool will also modify your Rakefile to load the jasmine tasks</
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -277,7 +277,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
 <span class="k">end</span></pre>
         </div>
       </td>
@@ -295,7 +295,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="n">show_console_log</span><span class="p">:</span> <span class="kp">true</span></pre>
+          <pre><span class="ss">show_console_log</span><span class="p">:</span> <span class="kp">true</span></pre>
         </div>
       </td>
     </tr>
@@ -308,7 +308,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="n">phantom_config_script</span><span class="p">:</span> <span class="s1">&#39;relative/path/from/project/root.js&#39;</span></pre>
+          <pre><span class="ss">phantom_config_script</span><span class="p">:</span> <span class="s1">&#39;relative/path/from/project/root.js&#39;</span></pre>
         </div>
       </td>
     </tr>
@@ -356,7 +356,7 @@ For an example of how to add your custom formatter see the <a href="#section-Con
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Formatter</span></pre>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -434,7 +434,7 @@ For an example of how to add your custom runner see the <a href="#section-Config
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Runner</span>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span>
   <span class="k">def</span> <span class="nf">initialize</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">jasmine_server_url</span><span class="p">,</span> <span class="n">result_batch_size</span><span class="p">)</span></pre>
         </div>
       </td>

--- a/2.2/src/introduction.js
+++ b/2.2/src/introduction.js
@@ -185,6 +185,17 @@ describe("Included matchers:", function() {
     expect(foo).not.toThrow();
     expect(bar).toThrow();
   });
+
+  it("The 'toThrowError' matcher is for testing a specific thrown exception", function() {
+    var foo = function() {
+      throw new TypeError("foo bar baz");
+    };
+
+    expect(foo).toThrowError("foo bar baz");
+    expect(foo).toThrowError(/bar/);
+    expect(foo).toThrowError(TypeError);
+    expect(foo).toThrowError(TypeError, "foo bar baz");
+  });
 });
 
 /**

--- a/edge/introduction.html
+++ b/edge/introduction.html
@@ -287,6 +287,17 @@ There is also the ability to write <a href="custom_matcher.html">custom matchers
     <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toThrow</span><span class="p">();</span>
     <span class="nx">expect</span><span class="p">(</span><span class="nx">bar</span><span class="p">).</span><span class="nx">toThrow</span><span class="p">();</span>
   <span class="p">});</span>
+
+  <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;The &#39;toThrowError&#39; matcher is for testing a specific thrown exception&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+    <span class="kd">var</span> <span class="nx">foo</span> <span class="o">=</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+      <span class="k">throw</span> <span class="k">new</span> <span class="nx">TypeError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="p">};</span>
+
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="sr">/bar/</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">);</span>
+    <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">toThrowError</span><span class="p">(</span><span class="nx">TypeError</span><span class="p">,</span> <span class="s2">&quot;foo bar baz&quot;</span><span class="p">);</span>
+  <span class="p">});</span>
 <span class="p">});</span></pre>
         </div>
       </td>

--- a/edge/ruby_gem.html
+++ b/edge/ruby_gem.html
@@ -262,7 +262,7 @@ The command line tool will also modify your Rakefile to load the jasmine tasks</
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">formatters</span> <span class="o">&lt;&lt;</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -277,7 +277,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="ss">My</span><span class="p">:</span><span class="ss">:Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
+          <pre>  <span class="n">config</span><span class="o">.</span><span class="n">runner</span> <span class="o">=</span> <span class="nb">lambda</span> <span class="p">{</span> <span class="o">|</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="o">|</span> <span class="no">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span><span class="o">.</span><span class="n">new</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">server_url</span><span class="p">,</span> <span class="mi">100</span><span class="p">)</span> <span class="p">}</span>
 <span class="k">end</span></pre>
         </div>
       </td>
@@ -295,7 +295,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="n">show_console_log</span><span class="p">:</span> <span class="kp">true</span></pre>
+          <pre><span class="ss">show_console_log</span><span class="p">:</span> <span class="kp">true</span></pre>
         </div>
       </td>
     </tr>
@@ -308,7 +308,7 @@ The lambda allows you to configure other options that need to be configured at i
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="n">phantom_config_script</span><span class="p">:</span> <span class="s1">&#39;relative/path/from/project/root.js&#39;</span></pre>
+          <pre><span class="ss">phantom_config_script</span><span class="p">:</span> <span class="s1">&#39;relative/path/from/project/root.js&#39;</span></pre>
         </div>
       </td>
     </tr>
@@ -356,7 +356,7 @@ For an example of how to add your custom formatter see the <a href="#section-Con
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Formatter</span></pre>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Formatter</span></pre>
         </div>
       </td>
     </tr>
@@ -434,7 +434,7 @@ For an example of how to add your custom runner see the <a href="#section-Config
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="ss">Custom</span><span class="p">:</span><span class="ss">:Runner</span>
+          <pre><span class="k">class</span> <span class="nc">My</span><span class="o">::</span><span class="no">Custom</span><span class="o">::</span><span class="no">Runner</span>
   <span class="k">def</span> <span class="nf">initialize</span><span class="p">(</span><span class="n">formatter</span><span class="p">,</span> <span class="n">jasmine_server_url</span><span class="p">,</span> <span class="n">result_batch_size</span><span class="p">)</span></pre>
         </div>
       </td>

--- a/edge/src/introduction.js
+++ b/edge/src/introduction.js
@@ -185,6 +185,17 @@ describe("Included matchers:", function() {
     expect(foo).not.toThrow();
     expect(bar).toThrow();
   });
+
+  it("The 'toThrowError' matcher is for testing a specific thrown exception", function() {
+    var foo = function() {
+      throw new TypeError("foo bar baz");
+    };
+
+    expect(foo).toThrowError("foo bar baz");
+    expect(foo).toThrowError(/bar/);
+    expect(foo).toThrowError(TypeError);
+    expect(foo).toThrowError(TypeError, "foo bar baz");
+  });
 });
 
 /**


### PR DESCRIPTION
`toThrowError` matcher was not documented. I could update the wording and the code if needed.