### PR TITLE
Install gems locally without affecting the system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 tmp/
+.bundle/
+vendor/
 */lib/specRunner*.html

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Contributing
 1. Fork the repo
 1. Create your feature branch (`git checkout -b my-new-docs`)
 1. Ensure ruby and bundler (`gem install bundler`) are installed
-1. Install ruby dependencies (`bundle`)
+1. Install ruby dependencies (`bundle install --path vendor/bundle`)
 1. Install pygments (pip install pygments) - would need python and pip (http://pygments.org/)
 1. Make your modifications
  1. Docs for new features go in `edge`
  1. Docs for existing release version go in that directory
  1. Modify the .js, .rb, or .py file in the `src` directory for the version being updated.
- 1. Run `rake pages` to rebuild the html pages for edge. If you're editing a different version you can set the `JASMINE_VERSION` environment variable.
+ 1. Run `bundle exec rake pages` to rebuild the html pages for edge. If you're editing a different version you can set the `JASMINE_VERSION` environment variable.
 1. Commit your changes (git commit -am 'Add some docs')
 1. Push to the branch (git push origin my-new-docs)
 1. Create new Pull Request

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'rubygems'
+require 'bundler/setup'
 require 'fileutils'
 require 'tilt'
 


### PR DESCRIPTION
I felt `sudo bundle` would unnecessarily pollute my system; quick googling suggests this is the way to install under current dir without requiring sudo (assuming ruby and bundler are already installed).
This _might_ lower the barrier to contributions a tiny bit.
It might also be entirely wrong, as I know nothing about Ruby Gems.

I can follow-up with a similar maneuver for `pip install pygments`, if you want.