### PR TITLE
Delete outdated fail() doc.

### DIFF
--- a/2.4/src/introduction.js
+++ b/2.4/src/introduction.js
@@ -199,25 +199,6 @@ describe("Included matchers:", function() {
 });
 
 /**
- ### Manually failing a spec with `fail`
- The `fail` function causes a spec to fail. It can take a failure message or an Error object as a parameter.
- */
-
-describe("A spec using the fail function", function() {
-  var foo = function(x, callBack) {
-    if (x) {
-      callBack();
-    }
-  };
-
-  it("should not call the callBack", function() {
-    foo(false, function() {
-      fail("Callback has been called");
-    });
-  });
-});
-
-/**
  ## Grouping Related Specs with `describe`
  The `describe` function is for grouping related specs. The string parameter is for naming the collection of specs, and will be concatenated with specs to make a spec's full name. This aids in finding specs in a large suite. If you name them well, your specs read as full sentences in traditional [BDD][bdd] style.
  [bdd]: http://en.wikipedia.org/wiki/Behavior-driven_development


### PR DESCRIPTION
The fail method no longer exists. This test was passing because x is false and thus the callback never fires. Jasmine perceived this as just having an `it` with no expectations:
```
A spec using the fail function
SPEC HAS NO EXPECTATIONS should not call the callBack
```