### PR TITLE
toContain matches substrings

### DIFF
--- a/1.3/src/introduction.js
+++ b/1.3/src/introduction.js
@@ -147,11 +147,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ['foo', 'bar', 'baz'];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain('bar');
-    expect(a).not.toContain('quux');
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/2.0/src/introduction.js
+++ b/2.0/src/introduction.js
@@ -143,11 +143,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ["foo", "bar", "baz"];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain("bar");
-    expect(a).not.toContain("quux");
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/2.1/src/introduction.js
+++ b/2.1/src/introduction.js
@@ -143,11 +143,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ["foo", "bar", "baz"];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain("bar");
-    expect(a).not.toContain("quux");
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/2.2/src/introduction.js
+++ b/2.2/src/introduction.js
@@ -143,11 +143,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ["foo", "bar", "baz"];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain("bar");
-    expect(a).not.toContain("quux");
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/2.3/src/introduction.js
+++ b/2.3/src/introduction.js
@@ -143,11 +143,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ["foo", "bar", "baz"];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain("bar");
-    expect(a).not.toContain("quux");
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/2.4/src/introduction.js
+++ b/2.4/src/introduction.js
@@ -143,11 +143,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ["foo", "bar", "baz"];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain("bar");
-    expect(a).not.toContain("quux");
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/edge/ajax.html
+++ b/edge/ajax.html
@@ -62,7 +62,7 @@ To use it, you need to download the <code>mock-ajax.js</code> file and add it to
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;mocking ajax&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
+          <pre><span></span><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;mocking ajax&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
         </div>
       </td>
     </tr>

--- a/edge/boot.html
+++ b/edge/boot.html
@@ -58,7 +58,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
+          <pre><span></span><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
         </div>
       </td>
     </tr>

--- a/edge/custom_boot.html
+++ b/edge/custom_boot.html
@@ -56,7 +56,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+          <pre><span></span><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
 
   <span class="nb">window</span><span class="p">.</span><span class="nx">jasmine</span> <span class="o">=</span> <span class="nx">jasmineRequire</span><span class="p">.</span><span class="nx">core</span><span class="p">(</span><span class="nx">jasmineRequire</span><span class="p">);</span>
 

--- a/edge/custom_equality.html
+++ b/edge/custom_equality.html
@@ -59,7 +59,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;custom equality&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
+          <pre><span></span><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;custom equality&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
         </div>
       </td>
     </tr>

--- a/edge/custom_matcher.html
+++ b/edge/custom_matcher.html
@@ -61,7 +61,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre></pre>
+          <pre><span></span></pre>
         </div>
       </td>
     </tr>

--- a/edge/custom_reporter.html
+++ b/edge/custom_reporter.html
@@ -59,7 +59,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre></pre>
+          <pre><span></span></pre>
         </div>
       </td>
     </tr>

--- a/edge/focused_specs.html
+++ b/edge/focused_specs.html
@@ -59,7 +59,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;Focused specs&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
+          <pre><span></span><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;Focused specs&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
         </div>
       </td>
     </tr>

--- a/edge/introduction.html
+++ b/edge/introduction.html
@@ -75,7 +75,7 @@ An expectation in Jasmine is an assertion that is either true or false. A spec w
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;A suite&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+          <pre><span></span><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;A suite&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
   <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;contains spec with an expectation&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
     <span class="nx">expect</span><span class="p">(</span><span class="kc">true</span><span class="p">).</span><span class="nx">toBe</span><span class="p">(</span><span class="kc">true</span><span class="p">);</span>
   <span class="p">});</span>
@@ -245,11 +245,20 @@ There is also the ability to write <a href="custom_matcher.html">custom matchers
     <span class="nx">expect</span><span class="p">(</span><span class="nx">foo</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toBeFalsy</span><span class="p">();</span>
   <span class="p">});</span>
 
-  <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;The &#39;toContain&#39; matcher is for finding an item in an Array&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
-    <span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;foo&quot;</span><span class="p">,</span> <span class="s2">&quot;bar&quot;</span><span class="p">,</span> <span class="s2">&quot;baz&quot;</span><span class="p">];</span>
+  <span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;The &#39;toContain&#39; matcher&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+    <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;works for finding an item in an Array&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+      <span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;foo&quot;</span><span class="p">,</span> <span class="s2">&quot;bar&quot;</span><span class="p">,</span> <span class="s2">&quot;baz&quot;</span><span class="p">];</span>
 
-    <span class="nx">expect</span><span class="p">(</span><span class="nx">a</span><span class="p">).</span><span class="nx">toContain</span><span class="p">(</span><span class="s2">&quot;bar&quot;</span><span class="p">);</span>
-    <span class="nx">expect</span><span class="p">(</span><span class="nx">a</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toContain</span><span class="p">(</span><span class="s2">&quot;quux&quot;</span><span class="p">);</span>
+      <span class="nx">expect</span><span class="p">(</span><span class="nx">a</span><span class="p">).</span><span class="nx">toContain</span><span class="p">(</span><span class="s2">&quot;bar&quot;</span><span class="p">);</span>
+      <span class="nx">expect</span><span class="p">(</span><span class="nx">a</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toContain</span><span class="p">(</span><span class="s2">&quot;quux&quot;</span><span class="p">);</span>
+    <span class="p">});</span>
+
+    <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;also works for finding a substring&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
+      <span class="kd">var</span> <span class="nx">a</span> <span class="o">=</span> <span class="s2">&quot;foo bar baz&quot;</span><span class="p">;</span>
+
+      <span class="nx">expect</span><span class="p">(</span><span class="nx">a</span><span class="p">).</span><span class="nx">toContain</span><span class="p">(</span><span class="s2">&quot;bar&quot;</span><span class="p">);</span>
+      <span class="nx">expect</span><span class="p">(</span><span class="nx">a</span><span class="p">).</span><span class="nx">not</span><span class="p">.</span><span class="nx">toContain</span><span class="p">(</span><span class="s2">&quot;quux&quot;</span><span class="p">);</span>
+    <span class="p">});</span>
   <span class="p">});</span>
 
   <span class="nx">it</span><span class="p">(</span><span class="s2">&quot;The &#39;toBeLessThan&#39; matcher is for mathematical comparisons&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span>

--- a/edge/node.html
+++ b/edge/node.html
@@ -56,7 +56,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre></pre>
+          <pre><span></span></pre>
         </div>
       </td>
     </tr>

--- a/edge/python_egg.html
+++ b/edge/python_egg.html
@@ -58,7 +58,7 @@ your code instead of manually editing script tags in the Jasmine runner HTML fil
       </td>
       <td class="code">
         <div class="highlight">
-          <pre></pre>
+          <pre><span></span></pre>
         </div>
       </td>
     </tr>

--- a/edge/ruby_gem.html
+++ b/edge/ruby_gem.html
@@ -56,7 +56,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre></pre>
+          <pre><span></span></pre>
         </div>
       </td>
     </tr>

--- a/edge/src/introduction.js
+++ b/edge/src/introduction.js
@@ -143,11 +143,20 @@ describe("Included matchers:", function() {
     expect(foo).not.toBeFalsy();
   });
 
-  it("The 'toContain' matcher is for finding an item in an Array", function() {
-    var a = ["foo", "bar", "baz"];
+  describe("The 'toContain' matcher", function() {
+    it("works for finding an item in an Array", function() {
+      var a = ["foo", "bar", "baz"];
 
-    expect(a).toContain("bar");
-    expect(a).not.toContain("quux");
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
+
+    it("also works for finding a substring", function() {
+      var a = "foo bar baz";
+
+      expect(a).toContain("bar");
+      expect(a).not.toContain("quux");
+    });
   });
 
   it("The 'toBeLessThan' matcher is for mathematical comparisons", function() {

--- a/edge/upgrading.html
+++ b/edge/upgrading.html
@@ -59,7 +59,7 @@
       </td>
       <td class="code">
         <div class="highlight">
-          <pre><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;Upgrading to jasmine 2.0&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
+          <pre><span></span><span class="nx">describe</span><span class="p">(</span><span class="s2">&quot;Upgrading to jasmine 2.0&quot;</span><span class="p">,</span> <span class="kd">function</span><span class="p">()</span> <span class="p">{</span></pre>
         </div>
       </td>
     </tr>


### PR DESCRIPTION
Addressing https://github.com/jasmine/jasmine/issues/981

`toContain` has a hidden feature (undocumented) that it matches substrings. I propose that we add this to the official docs so that people can discover it, and not worry about it disappearing.

There appear to be a few strange changes in the generated html (`<pre>` tags getting empty `<span>`s inserted in them). Please let me know if there's a setting to use when running `bundle exec rake pages` laid out in the README.