### PR TITLE
Use HTTPS version of site URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-baseurl: http://jasmine.github.io
+baseurl: https://jasmine.github.io
 exclude:
   - _tmp
   - src


### PR DESCRIPTION
Use the HTTPS version of the site (https://jasmine.github.io) to prevent Mixed Content errors
<img width="1277" alt="screen shot 2016-10-19 at 2 59 37 pm" src="https://cloud.githubusercontent.com/assets/3721994/19517925/ba6510c2-960c-11e6-8676-1fe146a70a19.png">
