### PR TITLE
Fix documentation of afterAll

### DIFF
--- a/_api/2.6/global.html
+++ b/_api/2.6/global.html
@@ -101,7 +101,7 @@ prettify: true
 
 
 <div class="description">
-    <p>Run some shared teardown once before all of the specs in the <a href="global.html#describe"><code>describe</code></a> are run.</p>
+    <p>Run some shared teardown once after all of the specs in the <a href="global.html#describe"><code>describe</code></a> are run.</p>
 <p><em>Note:</em> Be careful, sharing the teardown from a afterAll makes it easy to accidentally leak state between your specs so that they erroneously pass or fail.</p>
 </div>
 

--- a/_api/2.7/global.html
+++ b/_api/2.7/global.html
@@ -101,7 +101,7 @@ prettify: true
 
 
 <div class="description">
-    <p>Run some shared teardown once before all of the specs in the <a href="global.html#describe"><code>describe</code></a> are run.</p>
+    <p>Run some shared teardown once after all of the specs in the <a href="global.html#describe"><code>describe</code></a> are run.</p>
 <p><em>Note:</em> Be careful, sharing the teardown from a afterAll makes it easy to accidentally leak state between your specs so that they erroneously pass or fail.</p>
 </div>
 

--- a/_api/edge/global.html
+++ b/_api/edge/global.html
@@ -101,7 +101,7 @@ prettify: true
 
 
 <div class="description">
-    <p>Run some shared teardown once before all of the specs in the <a href="global.html#describe"><code>describe</code></a> are run.</p>
+    <p>Run some shared teardown once after all of the specs in the <a href="global.html#describe"><code>describe</code></a> are run.</p>
 <p><em>Note:</em> Be careful, sharing the teardown from a afterAll makes it easy to accidentally leak state between your specs so that they erroneously pass or fail.</p>
 </div>
 

--- a/_versions/2.6/lib/jasmine.js
+++ b/_versions/2.6/lib/jasmine.js
@@ -4085,7 +4085,7 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     },
 
     /**
-     * Run some shared teardown once before all of the specs in the {@link describe} are run.
+     * Run some shared teardown once after all of the specs in the {@link describe} are run.
      *
      * _Note:_ Be careful, sharing the teardown from a afterAll makes it easy to accidentally leak state between your specs so that they erroneously pass or fail.
      * @name afterAll

--- a/_versions/2.7/lib/jasmine.js
+++ b/_versions/2.7/lib/jasmine.js
@@ -4275,7 +4275,7 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     },
 
     /**
-     * Run some shared teardown once before all of the specs in the {@link describe} are run.
+     * Run some shared teardown once after all of the specs in the {@link describe} are run.
      *
      * _Note:_ Be careful, sharing the teardown from a afterAll makes it easy to accidentally leak state between your specs so that they erroneously pass or fail.
      * @name afterAll

--- a/_versions/edge/lib/jasmine.js
+++ b/_versions/edge/lib/jasmine.js
@@ -4275,7 +4275,7 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     },
 
     /**
-     * Run some shared teardown once before all of the specs in the {@link describe} are run.
+     * Run some shared teardown once after all of the specs in the {@link describe} are run.
      *
      * _Note:_ Be careful, sharing the teardown from a afterAll makes it easy to accidentally leak state between your specs so that they erroneously pass or fail.
      * @name afterAll


### PR DESCRIPTION
There's a misleading error in the documentation of `afterAll`. This PR is fixing it.