### PR TITLE
Fix whitespace/typesetting and add TOC to matchers page for all versions

### DIFF
--- a/_api/2.6/matchers.html
+++ b/_api/2.6/matchers.html
@@ -3,2652 +3,580 @@ layout: default
 title: "Namespace: matchers"
 prettify: true
 ---
-
 <div class="main-content api-docs">
-  <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="Clock.html">Clock</a></li><li><a href="Env.html">Env</a></li><li><a href="jsApiReporter.html">jsApiReporter</a></li><li><a href="Spy.html">Spy</a></li></ul><h3>Namespaces</h3><ul><li><a href="jasmine.html">jasmine</a></li><li><a href="matchers.html">matchers</a></li><li><a href="Spy_and.html">Spy#and</a></li><li><a href="Spy_calls.html">Spy#calls</a></li></ul><h3>Global</h3><ul><li><a href="global.html#afterAll">afterAll</a></li><li><a href="global.html#afterEach">afterEach</a></li><li><a href="global.html#beforeAll">beforeAll</a></li><li><a href="global.html#beforeEach">beforeEach</a></li><li><a href="global.html#describe">describe</a></li><li><a href="global.html#expect">expect</a></li><li><a href="global.html#fail">fail</a></li><li><a href="global.html#fdescribe">fdescribe</a></li><li><a href="global.html#fit">fit</a></li><li><a href="global.html#it">it</a></li><li><a href="global.html#pending">pending</a></li><li><a href="global.html#spyOn">spyOn</a></li><li><a href="global.html#spyOnProperty">spyOnProperty</a></li><li><a href="global.html#xdescribe">xdescribe</a></li><li><a href="global.html#xit">xit</a></li></ul>
-  </nav>
-
-  <div class="docs">
-    <h1 class="page-title">Namespace: matchers</h1>
-
-    
-
-
-
-
-<section>
-
-<header>
-    
-        <h2>matchers</h2>
-        
-    
-</header>
-
-<article>
-    <div class="container-overview">
-    
-        
-            <div class="description"><p>Matchers that come with Jasmine out of the box.</p></div>
-        
-
-        
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-        
-    
+    <nav>
+        <h2><a href="index.html">Home</a></h2>
+        <h3>Classes</h3>
+        <ul>
+            <li><a href="Clock.html">Clock</a></li>
+            <li><a href="Env.html">Env</a></li>
+            <li><a href="jsApiReporter.html">jsApiReporter</a></li>
+            <li><a href="Spy.html">Spy</a></li>
+        </ul>
+        <h3>Namespaces</h3>
+        <ul>
+            <li><a href="jasmine.html">jasmine</a></li>
+            <li><a href="matchers.html">matchers</a></li>
+            <li><a href="Spy_and.html">Spy#and</a></li>
+            <li><a href="Spy_calls.html">Spy#calls</a></li>
+        </ul>
+        <h3>Global</h3>
+        <ul>
+            <li><a href="global.html#afterAll">afterAll</a></li>
+            <li><a href="global.html#afterEach">afterEach</a></li>
+            <li><a href="global.html#beforeAll">beforeAll</a></li>
+            <li><a href="global.html#beforeEach">beforeEach</a></li>
+            <li><a href="global.html#describe">describe</a></li>
+            <li><a href="global.html#expect">expect</a></li>
+            <li><a href="global.html#fail">fail</a></li>
+            <li><a href="global.html#fdescribe">fdescribe</a></li>
+            <li><a href="global.html#fit">fit</a></li>
+            <li><a href="global.html#it">it</a></li>
+            <li><a href="global.html#pending">pending</a></li>
+            <li><a href="global.html#spyOn">spyOn</a></li>
+            <li><a href="global.html#spyOnProperty">spyOnProperty</a></li>
+            <li><a href="global.html#xdescribe">xdescribe</a></li>
+            <li><a href="global.html#xit">xit</a></li>
+        </ul>
+    </nav>
+    <div class="docs">
+        <h1 class="page-title">Namespace: matchers</h1>
+        <header>
+            <h2>matchers</h2>
+        </header>
+        <article>
+            <div class="container-overview">
+                <div class="description">
+                    <p>Matchers that come with Jasmine out of the box.</p>
+                </div>
+            </div>
+            <h3 class="subsection-title">Table of Contents</h3>
+            <ul>
+                <li><a href="#toBe">toBe</a></li>
+                <li><a href="#toBeCloseTo">toBeCloseTo</a></li>
+                <li><a href="#toBeDefined">toBeFalsy</a></li>
+                <li><a href="#toBeFalsy">toBeDefined</a></li>
+                <li><a href="#toBeGreaterThan">toBeGreaterThan</a></li>
+                <li><a href="#toBeGreaterThanOrEqual">toHaveBeenCalledBefore</a></li>
+                <li><a href="#toBeLessThan">toBeGreaterThanOrEqual</a></li>
+                <li><a href="#toBeLessThanOrEqual">toBeLessThan</a></li>
+                <li><a href="#toBeNaN">toBeLessThanOrEqual</a></li>
+                <li><a href="#toBeNull">toBeNaN</a></li>
+                <li><a href="#toBeTruthy">toBeNull</a></li>
+                <li><a href="#toBeUndefined">toBeTruthy</a></li>
+                <li><a href="#toContain">toBeUndefined</a></li>
+                <li><a href="#toEqual">toContain</a></li>
+                <li><a href="#toHaveBeenCalledBefore">toEqual</a></li>
+                <li><a href="#toHaveBeenCalledTimes">toHaveBeenCalledTimes</a></li>
+                <li><a href="#toHaveBeenCalledWith">toHaveBeenCalledWith</a></li>
+                <li><a href="#toMatch">toMatch</a></li>
+                <li><a href="#toThrow">toThrow</a></li>
+                <li><a href="#toThrowError " toThrowError></a></li>
+                <li><a href="#toHaveBeenCalled">toHaveBeenCalled</a></li>
+            </ul>
+            <h3 class="subsection-title">Methods</h3>
+            <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected
+                    value.
+                </p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Object</span>
+                        </td>
+                        <td class="description last">
+                            <p>The expected value to compare against.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
+            <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span>
+                <span class="type-signature"></span>
+            </h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision
+                    of the expected value.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Attributes</th>
+                        <th>Default</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Object</span>
+                        </td>
+                        <td class="attributes">
+                        </td>
+                        <td class="default">
+                        </td>
+                        <td class="description last">
+                            <p>The expected value to compare against.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="name"><code>precision</code></td>
+                        <td class="type">
+                            <span class="param-type">Number</span>
+                        </td>
+                        <td class="attributes">
+                            &lt;optional><br>
+                        </td>
+                        <td class="default">
+                            2
+                        </td>
+                        <td class="description last">
+                            <p>The number of decimal points to check.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
+            <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
+            <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
+            <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected value.
+                </p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Number</span>
+                        </td>
+                        <td class="description last">
+                            <p>The value to compare against.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
+            <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span>
+                <span class="type-signature"></span>
+            </h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to the
+                    expected value.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Number</span>
+                        </td>
+                        <td class="description last">
+                            <p>The expected value to compare against.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
+            <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Number</span>
+                        </td>
+                        <td class="description last">
+                            <p>The expected value to compare against.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
+            <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the expected
+                    value.
+                </p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Number</span>
+                        </td>
+                        <td class="description last">
+                            <p>The expected value to compare against.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
+            <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
+            <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
+            <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
+            <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
+            <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Object</span>
+                        </td>
+                        <td class="description last">
+                            <p>The value to look for.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(array).toContain(anElement);
+                                expect(string).toContain(substring);</code></pre>
+            <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using
+                    deep equality comparison.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Object</span>
+                        </td>
+                        <td class="description last">
+                            <p>Expected value</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
+            <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                    to have been called.</p>
+            </div>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
+                                            expect(mySpy).not.toHaveBeenCalled();</code></pre>
+            <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span>
+                <span class="type-signature"></span>
+            </h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>)
+                    to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type"><a href="Spy.html">Spy</a></span>
+                        </td>
+                        <td class="description last">
+                            <p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code>                                <a href="Spy.html"><code>Spy</code></a>.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
+            <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                    to have been called the specified number of times.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Number</span>
+                        </td>
+                        <td class="description last">
+                            <p>The number of invocations to look for.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
+            <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                    to have been called with particular arguments at least once.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Type</th>
+                        <th>Attributes</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="type">
+                            <span class="param-type">Object</span>
+                        </td>
+                        <td class="attributes">
+                            &lt;repeatable><br>
+                        </td>
+                        <td class="description last">
+                            <p>The arguments to look for</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
+            <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">RegExp</span> |
+                            <span class="param-type">String</span>
+                        </td>
+                        <td class="description last">
+                            <p>Value to look for in the string.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
+                                                            expect("other string").toMatch("her");</code></pre>
+            <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span>
+                <span class="type-signature"></span>
+            </h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Attributes</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Object</span>
+                        </td>
+                        <td class="attributes">
+                            &lt;optional><br>
+                        </td>
+                        <td class="description last">
+                            <p>Value that should be thrown. If not provided, simply the fact that something was thrown will
+                                be checked.</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
+                                                                    expect(function() { return 'stuff'; }).toThrow();</code></pre>
+            <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>,
+                message
+                <span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
+            <div class="description">
+                <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
+            </div>
+            <h5>Parameters:</h5>
+            <table class="params">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Attributes</th>
+                        <th class="last">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="name"><code>expected</code></td>
+                        <td class="type">
+                            <span class="param-type">Error</span>
+                        </td>
+                        <td class="attributes">
+                            &lt;optional><br>
+                        </td>
+                        <td class="description last">
+                            <p><code>Error</code> constructor the object that was thrown needs to be an instance of. If not
+                                provided, <code>Error</code> will be used.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="name"><code>message</code></td>
+                        <td class="type">
+                            <span class="param-type">RegExp</span> |
+                            <span class="param-type">String</span>
+                        </td>
+                        <td class="attributes">
+                            &lt;optional><br>
+                        </td>
+                        <td class="description last">
+                            <p>The message that should be set on the thrown <code>Error</code></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Example</h5>
+            <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
+                                                                                expect(function() { return 'things'; }).toThrowError(MyCustomError, /bar/);
+                                                                                expect(function() { return 'stuff'; }).toThrowError(MyCustomError);
+                                                                                expect(function() { return 'other'; }).toThrowError(/foo/);
+                                                                                expect(function() { return 'other'; }).toThrowError();</code></pre>
+        </article>
+        </section>
     </div>
-
-    
-
-    
-
-    
-
-     
-
-    
-
-    
-
-    
-        <h3 class="subsection-title">Methods</h3>
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision of the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>precision</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    2
-                
-                </td>
-            
-
-            <td class="description last"><p>The number of decimal points to check.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(array).toContain(anElement);
-expect(string).toContain(substring);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using deep equality comparison.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Expected value</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
-expect(mySpy).not.toHaveBeenCalled();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>) to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><a href="Spy.html">Spy</a></span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code> <a href="Spy.html"><code>Spy</code></a>.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called the specified number of times.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The number of invocations to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called with particular arguments at least once.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The arguments to look for</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Value to look for in the string.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
-expect("other string").toMatch("her");</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>Value that should be thrown. If not provided, simply the fact that something was thrown will be checked.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
-expect(function() { return 'stuff'; }).toThrow();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>, message<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Error</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p><code>Error</code> constructor the object that was thrown needs to be an instance of. If not provided, <code>Error</code> will be used.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>message</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The message that should be set on the thrown <code>Error</code></p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
-expect(function() { return 'things'; }).toThrowError(MyCustomError, /bar/);
-expect(function() { return 'stuff'; }).toThrowError(MyCustomError);
-expect(function() { return 'other'; }).toThrowError(/foo/);
-expect(function() { return 'other'; }).toThrowError();</code></pre>
-
-
-
-        
-    
-
-    
-
-    
-</article>
-
-</section>
-
-
-
-
-  </div>
-
-  <footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.4.3</a> on Thu Mar 23 2017 16:53:17 GMT-0700 (PDT)
-  </footer>
+    <footer>
+        Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.4.3</a> on Thu Mar 23 2017 16:53:17
+        GMT-0700 (PDT)
+    </footer>
 </div>

--- a/_api/2.7/matchers.html
+++ b/_api/2.7/matchers.html
@@ -3,2816 +3,595 @@ layout: default
 title: "Namespace: matchers"
 prettify: true
 ---
-
 <div class="main-content api-docs">
-  <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="Clock.html">Clock</a></li><li><a href="Env.html">Env</a></li><li><a href="jsApiReporter.html">jsApiReporter</a></li><li><a href="Spy.html">Spy</a></li></ul><h3>Namespaces</h3><ul><li><a href="jasmine.html">jasmine</a></li><li><a href="matchers.html">matchers</a></li><li><a href="Spy_and.html">Spy#and</a></li><li><a href="Spy_calls.html">Spy#calls</a></li></ul><h3>Global</h3><ul><li><a href="global.html#afterAll">afterAll</a></li><li><a href="global.html#afterEach">afterEach</a></li><li><a href="global.html#beforeAll">beforeAll</a></li><li><a href="global.html#beforeEach">beforeEach</a></li><li><a href="global.html#describe">describe</a></li><li><a href="global.html#expect">expect</a></li><li><a href="global.html#fail">fail</a></li><li><a href="global.html#fdescribe">fdescribe</a></li><li><a href="global.html#fit">fit</a></li><li><a href="global.html#it">it</a></li><li><a href="global.html#pending">pending</a></li><li><a href="global.html#spyOn">spyOn</a></li><li><a href="global.html#spyOnProperty">spyOnProperty</a></li><li><a href="global.html#xdescribe">xdescribe</a></li><li><a href="global.html#xit">xit</a></li></ul>
-  </nav>
-
-  <div class="docs">
-    <h1 class="page-title">Namespace: matchers</h1>
-
-    
-
-
-
-
-<section>
-
-<header>
-    
-        <h2>matchers</h2>
-        
-    
-</header>
-
-<article>
-    <div class="container-overview">
-    
-        
-            <div class="description"><p>Matchers that come with Jasmine out of the box.</p></div>
-        
-
-        
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-        
-    
-    </div>
-
-    
-
-    
-
-    
-
-     
-
-    
-
-    
-
-    
-        <h3 class="subsection-title">Methods</h3>
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision of the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>precision</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    2
-                
-                </td>
-            
-
-            <td class="description last"><p>The number of decimal points to check.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeNegativeInfinity"><span class="type-signature"></span>toBeNegativeInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>-Infinity</code> (-infinity).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNegativeInfinity();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBePositiveInfinity"><span class="type-signature"></span>toBePositiveInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>Infinity</code> (infinity).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBePositiveInfinity();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(array).toContain(anElement);
+    <nav>
+        <h2><a href="index.html">Home</a></h2>
+        <h3>Classes</h3>
+        <ul>
+            <li><a href="Clock.html">Clock</a></li>
+            <li><a href="Env.html">Env</a></li>
+            <li><a href="jsApiReporter.html">jsApiReporter</a></li>
+            <li><a href="Spy.html">Spy</a></li>
+        </ul>
+        <h3>Namespaces</h3>
+        <ul>
+            <li><a href="jasmine.html">jasmine</a></li>
+            <li><a href="matchers.html">matchers</a></li>
+            <li><a href="Spy_and.html">Spy#and</a></li>
+            <li><a href="Spy_calls.html">Spy#calls</a></li>
+        </ul>
+        <h3>Global</h3>
+        <ul>
+            <li><a href="global.html#afterAll">afterAll</a></li>
+            <li><a href="global.html#afterEach">afterEach</a></li>
+            <li><a href="global.html#beforeAll">beforeAll</a></li>
+            <li><a href="global.html#beforeEach">beforeEach</a></li>
+            <li><a href="global.html#describe">describe</a></li>
+            <li><a href="global.html#expect">expect</a></li>
+            <li><a href="global.html#fail">fail</a></li>
+            <li><a href="global.html#fdescribe">fdescribe</a></li>
+            <li><a href="global.html#fit">fit</a></li>
+            <li><a href="global.html#it">it</a></li>
+            <li><a href="global.html#pending">pending</a></li>
+            <li><a href="global.html#spyOn">spyOn</a></li>
+            <li><a href="global.html#spyOnProperty">spyOnProperty</a></li>
+            <li><a href="global.html#xdescribe">xdescribe</a></li>
+            <li><a href="global.html#xit">xit</a></li>
+        </ul>
+    </nav>
+    <div class="docs">
+        <h1 class="page-title">Namespace: matchers</h1>
+        <section>
+            <header>
+                <h2>matchers</h2>
+            </header>
+            <article>
+                <div class="container-overview">
+                    <div class="description">
+                        <p>Matchers that come with Jasmine out of the box.</p>
+                    </div>
+                </div>
+                <h3 class="subsection-title">Table of Contents</h3>
+                <ul>
+                    <li><a href="#toBe">toBe</a></li>
+                    <li><a href="#toBeCloseTo">toBeCloseTo</a></li>
+                    <li><a href="#toBeDefined">toBeDefined</a></li>
+                    <li><a href="#toBeFalsy">toBeFalsy</a></li>
+                    <li><a href="#toBeGreaterThan">toBeGreaterThan</a></li>
+                    <li><a href="#toBeGreaterThanOrEqual">toBeGreaterThanOrEqual</a></li>
+                    <li><a href="#toBeLessThan">toBeLessThan</a></li>
+                    <li><a href="#toBeLessThanOrEqual">toBeLessThanOrEqual</a></li>
+                    <li><a href="#toBeNaN">toBeNaN</a></li>
+                    <li><a href="#toBeNegativeInfinity">toBeNegativeInfinity</a></li>
+                    <li><a href="#toBeNull">toBeNull</a></li>
+                    <li><a href="#toBePositiveInfinity">toBePositiveInfinity</a></li>
+                    <li><a href="#toBeTruthy">toBeTruthy</a></li>
+                    <li><a href="#toBeUndefined">toBeUndefined</a></li>
+                    <li><a href="#toContain">toContain</a></li>
+                    <li><a href="#toEqual">toEqual</a></li>
+                    <li><a href="#toHaveBeenCalled">toHaveBeenCalled</a></li>
+                    <li><a href="#toHaveBeenCalledBefore">toHaveBeenCalledBefore</a></li>
+                    <li><a href="#toHaveBeenCalledTimes">toHaveBeenCalledTimes</a></li>
+                    <li><a href="#toHaveBeenCalledWith">toHaveBeenCalledWith</a></li>
+                    <li><a href="#toMatch">toMatch</a></li>
+                    <li><a href="#toThrow">toThrow</a></li>
+                    <li><a href="#toThrowError">toThrowError</a></li>
+                </ul>
+                <h3 class="subsection-title">Methods</h3>
+                <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected
+                        value.
+                    </p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
+                <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision
+                        of the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th>Default</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                            </td>
+                            <td class="default">
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="name"><code>precision</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="default">
+                                2
+                            </td>
+                            <td class="description last">
+                                <p>The number of decimal points to check.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
+                <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
+                <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
+                <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected
+                        value.
+                    </p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
+                <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to
+                        the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
+                <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
+                <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the
+                        expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
+                <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
+                <h4 class="name" id="toBeNegativeInfinity"><span class="type-signature"></span>toBeNegativeInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>-Infinity</code> (-infinity).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeNegativeInfinity();</code></pre>
+                <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
+                <h4 class="name" id="toBePositiveInfinity"><span class="type-signature"></span>toBePositiveInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>Infinity</code> (infinity).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBePositiveInfinity();</code></pre>
+                <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
+                <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
+                <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>The value to look for.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(array).toContain(anElement);
 expect(string).toContain(substring);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using deep equality comparison.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Expected value</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
+                <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using
+                        deep equality comparison.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>Expected value</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
+                <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
 expect(mySpy).not.toHaveBeenCalled();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>) to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><a href="Spy.html">Spy</a></span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code> <a href="Spy.html"><code>Spy</code></a>.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called the specified number of times.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The number of invocations to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called with particular arguments at least once.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The arguments to look for</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Value to look for in the string.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
+                <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type"><a href="Spy.html">Spy</a></span>
+                            </td>
+                            <td class="description last">
+                                <p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code>                                    <a href="Spy.html"><code>Spy</code></a>.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
+                <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called the specified number of times.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The number of invocations to look for.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
+                <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called with particular arguments at least once.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;repeatable><br>
+                            </td>
+                            <td class="description last">
+                                <p>The arguments to look for</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
+                <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">RegExp</span> |
+                                <span class="param-type">String</span>
+                            </td>
+                            <td class="description last">
+                                <p>Value to look for in the string.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
 expect("other string").toMatch("her");</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>Value that should be thrown. If not provided, simply the fact that something was thrown will be checked.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
+                <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p>Value that should be thrown. If not provided, simply the fact that something was thrown will
+                                    be checked.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
 expect(function() { return 'stuff'; }).toThrow();</code></pre>
-
-
-
-        
-            
-
-    
-
-    <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>, message<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Error</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p><code>Error</code> constructor the object that was thrown needs to be an instance of. If not provided, <code>Error</code> will be used.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>message</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The message that should be set on the thrown <code>Error</code></p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
+                <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>,
+                    message
+                    <span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Error</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p><code>Error</code> constructor the object that was thrown needs to be an instance of. If
+                                    not provided, <code>Error</code> will be used.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="name"><code>message</code></td>
+                            <td class="type">
+                                <span class="param-type">RegExp</span> |
+                                <span class="param-type">String</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p>The message that should be set on the thrown <code>Error</code></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
 expect(function() { return 'things'; }).toThrowError(MyCustomError, /bar/);
 expect(function() { return 'stuff'; }).toThrowError(MyCustomError);
 expect(function() { return 'other'; }).toThrowError(/foo/);
 expect(function() { return 'other'; }).toThrowError();</code></pre>
-
-
-
-        
-    
-
-    
-
-    
-</article>
-
-</section>
-
-
-
-
-  </div>
-
-  <footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.4.3</a> on Sat Jul 29 2017 14:21:54 GMT-0700 (PDT)
-  </footer>
+            </article>
+        </section>
+    </div>
+    <footer>
+        Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.4.3</a> on Sat Jul 29 2017 14:21:54
+        GMT-0700 (PDT)
+    </footer>
 </div>

--- a/_api/2.8/matchers.html
+++ b/_api/2.8/matchers.html
@@ -3,2996 +3,606 @@ layout: default
 title: "Namespace: matchers"
 prettify: true
 ---
-
 <div class="main-content api-docs">
-  <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="Clock.html">Clock</a></li><li><a href="Env.html">Env</a></li><li><a href="jsApiReporter.html">jsApiReporter</a></li><li><a href="Spy.html">Spy</a></li></ul><h3>Namespaces</h3><ul><li><a href="jasmine.html">jasmine</a></li><li><a href="matchers.html">matchers</a></li><li><a href="Spy_and.html">Spy#and</a></li><li><a href="Spy_calls.html">Spy#calls</a></li></ul><h3>Interfaces</h3><ul><li><a href="Reporter.html">Reporter</a></li></ul><h3>Global</h3><ul><li><a href="global.html#afterAll">afterAll</a></li><li><a href="global.html#afterEach">afterEach</a></li><li><a href="global.html#beforeAll">beforeAll</a></li><li><a href="global.html#beforeEach">beforeEach</a></li><li><a href="global.html#describe">describe</a></li><li><a href="global.html#expect">expect</a></li><li><a href="global.html#fail">fail</a></li><li><a href="global.html#fdescribe">fdescribe</a></li><li><a href="global.html#fit">fit</a></li><li><a href="global.html#it">it</a></li><li><a href="global.html#pending">pending</a></li><li><a href="global.html#spyOn">spyOn</a></li><li><a href="global.html#spyOnProperty">spyOnProperty</a></li><li><a href="global.html#xdescribe">xdescribe</a></li><li><a href="global.html#xit">xit</a></li></ul>
-  </nav>
-
-  <div class="docs">
-    <h1 class="page-title">Namespace: matchers</h1>
-
-    
-
-
-
-
-<section>
-
-<header>
-    
-        <h2>matchers</h2>
-        
-    
-</header>
-
-<article>
-    <div class="container-overview">
-    
-        
-            <div class="description"><p>Matchers that come with Jasmine out of the box.</p></div>
-        
-
-        
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-        
-    
-    </div>
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-        <h3 class="subsection-title">Methods</h3>
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="nothing"><span class="type-signature"></span>nothing<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> nothing explicitly.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect().nothing();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision of the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>precision</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    2
-                
-                </td>
-            
-
-            <td class="description last"><p>The number of decimal points to check.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeNegativeInfinity"><span class="type-signature"></span>toBeNegativeInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>-Infinity</code> (-infinity).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNegativeInfinity();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBePositiveInfinity"><span class="type-signature"></span>toBePositiveInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>Infinity</code> (infinity).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBePositiveInfinity();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(array).toContain(anElement);
+    <nav>
+        <h2><a href="index.html">Home</a></h2>
+        <h3>Classes</h3>
+        <ul>
+            <li><a href="Clock.html">Clock</a></li>
+            <li><a href="Env.html">Env</a></li>
+            <li><a href="jsApiReporter.html">jsApiReporter</a></li>
+            <li><a href="Spy.html">Spy</a></li>
+        </ul>
+        <h3>Namespaces</h3>
+        <ul>
+            <li><a href="jasmine.html">jasmine</a></li>
+            <li><a href="matchers.html">matchers</a></li>
+            <li><a href="Spy_and.html">Spy#and</a></li>
+            <li><a href="Spy_calls.html">Spy#calls</a></li>
+        </ul>
+        <h3>Interfaces</h3>
+        <ul>
+            <li><a href="Reporter.html">Reporter</a></li>
+        </ul>
+        <h3>Global</h3>
+        <ul>
+            <li><a href="global.html#afterAll">afterAll</a></li>
+            <li><a href="global.html#afterEach">afterEach</a></li>
+            <li><a href="global.html#beforeAll">beforeAll</a></li>
+            <li><a href="global.html#beforeEach">beforeEach</a></li>
+            <li><a href="global.html#describe">describe</a></li>
+            <li><a href="global.html#expect">expect</a></li>
+            <li><a href="global.html#fail">fail</a></li>
+            <li><a href="global.html#fdescribe">fdescribe</a></li>
+            <li><a href="global.html#fit">fit</a></li>
+            <li><a href="global.html#it">it</a></li>
+            <li><a href="global.html#pending">pending</a></li>
+            <li><a href="global.html#spyOn">spyOn</a></li>
+            <li><a href="global.html#spyOnProperty">spyOnProperty</a></li>
+            <li><a href="global.html#xdescribe">xdescribe</a></li>
+            <li><a href="global.html#xit">xit</a></li>
+        </ul>
+    </nav>
+    <div class="docs">
+        <h1 class="page-title">Namespace: matchers</h1>
+        <section>
+            <header>
+                <h2>matchers</h2>
+            </header>
+            <article>
+                <div class="container-overview">
+                    <div class="description">
+                        <p>Matchers that come with Jasmine out of the box.</p>
+                    </div>
+                </div>
+                <h3 class="subsection-title">Table of Contents</h3>
+                <ul>
+                    <li><a href="#nothing">nothing</a></li>
+                    <li><a href="#toBe">toBe</a></li>
+                    <li><a href="#toBeCloseTo">toBeCloseTo</a></li>
+                    <li><a href="#toBeDefined">toBeDefined</a></li>
+                    <li><a href="#toBeFalsy">toBeFalsy</a></li>
+                    <li><a href="#toBeGreaterThan">toBeGreaterThan</a></li>
+                    <li><a href="#toBeGreaterThanOrEqual">toBeGreaterThanOrEqual</a></li>
+                    <li><a href="#toBeLessThan">toBeLessThan</a></li>
+                    <li><a href="#toBeLessThanOrEqual">toBeLessThanOrEqual</a></li>
+                    <li><a href="#toBeNaN">toBeNaN</a></li>
+                    <li><a href="#toBeNegativeInfinity">toBeNegativeInfinity</a></li>
+                    <li><a href="#toBeNull">toBeNull</a></li>
+                    <li><a href="#toBePositiveInfinity">toBePositiveInfinity</a></li>
+                    <li><a href="#toBeTruthy">toBeTruthy</a></li>
+                    <li><a href="#toBeUndefined">toBeUndefined</a></li>
+                    <li><a href="#toContain">toContain</a></li>
+                    <li><a href="#toEqual">toEqual</a></li>
+                    <li><a href="#toHaveBeenCalled">toHaveBeenCalled</a></li>
+                    <li><a href="#toHaveBeenCalledBefore">toHaveBeenCalledBefore</a></li>
+                    <li><a href="#toHaveBeenCalledTimes">toHaveBeenCalledTimes</a></li>
+                    <li><a href="#toHaveBeenCalledWith">toHaveBeenCalledWith</a></li>
+                    <li><a href="#toMatch">toMatch</a></li>
+                    <li><a href="#toThrow">toThrow</a></li>
+                    <li><a href="#toThrowError">toThrowError</a></li>
+                </ul>
+                <h3 class="subsection-title">Methods</h3>
+                <h4 class="name" id="nothing"><span class="type-signature"></span>nothing<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> nothing explicitly.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect().nothing();</code></pre>
+                <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected
+                        value.
+                    </p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
+                <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision
+                        of the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th>Default</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                            </td>
+                            <td class="default">
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="name"><code>precision</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="default">
+                                2
+                            </td>
+                            <td class="description last">
+                                <p>The number of decimal points to check.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
+                <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
+                <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
+                <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected
+                        value.
+                    </p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
+                <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to
+                        the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
+                <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
+                <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the
+                        expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
+                <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
+                <h4 class="name" id="toBeNegativeInfinity"><span class="type-signature"></span>toBeNegativeInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>-Infinity</code> (-infinity).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeNegativeInfinity();</code></pre>
+                <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
+                <h4 class="name" id="toBePositiveInfinity"><span class="type-signature"></span>toBePositiveInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>Infinity</code> (infinity).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBePositiveInfinity();</code></pre>
+                <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
+                <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
+                <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>The value to look for.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(array).toContain(anElement);
 expect(string).toContain(substring);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using deep equality comparison.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Expected value</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
+                <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using
+                        deep equality comparison.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>Expected value</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
+                <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
 expect(mySpy).not.toHaveBeenCalled();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>) to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><a href="Spy.html">Spy</a></span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code> <a href="Spy.html"><code>Spy</code></a>.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called the specified number of times.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The number of invocations to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called with particular arguments at least once.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The arguments to look for</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Value to look for in the string.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
+                <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type"><a href="Spy.html">Spy</a></span>
+                            </td>
+                            <td class="description last">
+                                <p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code>                                    <a href="Spy.html"><code>Spy</code></a>.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
+                <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called the specified number of times.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The number of invocations to look for.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
+                <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called with particular arguments at least once.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;repeatable><br>
+                            </td>
+                            <td class="description last">
+                                <p>The arguments to look for</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
+                <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">RegExp</span> |
+                                <span class="param-type">String</span>
+                            </td>
+                            <td class="description last">
+                                <p>Value to look for in the string.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
 expect("other string").toMatch("her");</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>Value that should be thrown. If not provided, simply the fact that something was thrown will be checked.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
+                <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p>Value that should be thrown. If not provided, simply the fact that something was thrown will
+                                    be checked.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
 expect(function() { return 'stuff'; }).toThrow();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>, message<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Error</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p><code>Error</code> constructor the object that was thrown needs to be an instance of. If not provided, <code>Error</code> will be used.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>message</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The message that should be set on the thrown <code>Error</code></p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
+                <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>,
+                    message
+                    <span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Error</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p><code>Error</code> constructor the object that was thrown needs to be an instance of. If
+                                    not provided, <code>Error</code> will be used.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="name"><code>message</code></td>
+                            <td class="type">
+                                <span class="param-type">RegExp</span> |
+                                <span class="param-type">String</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p>The message that should be set on the thrown <code>Error</code></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
 expect(function() { return 'things'; }).toThrowError(MyCustomError, /bar/);
 expect(function() { return 'stuff'; }).toThrowError(MyCustomError);
 expect(function() { return 'other'; }).toThrowError(/foo/);
 expect(function() { return 'other'; }).toThrowError();</code></pre>
-
-
-
-        
-    
-
-    
-
-    
-</article>
-
-</section>
-
-
-
-
-  </div>
-
-  <footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.4</a> on Thu Aug 24 2017 12:23:17 GMT-0700 (PDT)
-  </footer>
+            </article>
+        </section>
+    </div>
+    <footer>
+        Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.4</a> on Thu Aug 24 2017 12:23:17
+        GMT-0700 (PDT)
+    </footer>
 </div>

--- a/_api/edge/matchers.html
+++ b/_api/edge/matchers.html
@@ -3,2996 +3,606 @@ layout: default
 title: "Namespace: matchers"
 prettify: true
 ---
-
 <div class="main-content api-docs">
-  <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="Clock.html">Clock</a></li><li><a href="Env.html">Env</a></li><li><a href="jsApiReporter.html">jsApiReporter</a></li><li><a href="Spy.html">Spy</a></li></ul><h3>Namespaces</h3><ul><li><a href="jasmine.html">jasmine</a></li><li><a href="matchers.html">matchers</a></li><li><a href="Spy_and.html">Spy#and</a></li><li><a href="Spy_calls.html">Spy#calls</a></li></ul><h3>Interfaces</h3><ul><li><a href="Reporter.html">Reporter</a></li></ul><h3>Global</h3><ul><li><a href="global.html#afterAll">afterAll</a></li><li><a href="global.html#afterEach">afterEach</a></li><li><a href="global.html#beforeAll">beforeAll</a></li><li><a href="global.html#beforeEach">beforeEach</a></li><li><a href="global.html#describe">describe</a></li><li><a href="global.html#expect">expect</a></li><li><a href="global.html#fail">fail</a></li><li><a href="global.html#fdescribe">fdescribe</a></li><li><a href="global.html#fit">fit</a></li><li><a href="global.html#it">it</a></li><li><a href="global.html#pending">pending</a></li><li><a href="global.html#spyOn">spyOn</a></li><li><a href="global.html#spyOnProperty">spyOnProperty</a></li><li><a href="global.html#xdescribe">xdescribe</a></li><li><a href="global.html#xit">xit</a></li></ul>
-  </nav>
-
-  <div class="docs">
-    <h1 class="page-title">Namespace: matchers</h1>
-
-    
-
-
-
-
-<section>
-
-<header>
-    
-        <h2>matchers</h2>
-        
-    
-</header>
-
-<article>
-    <div class="container-overview">
-    
-        
-            <div class="description"><p>Matchers that come with Jasmine out of the box.</p></div>
-        
-
-        
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-        
-    
-    </div>
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-        <h3 class="subsection-title">Methods</h3>
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="nothing"><span class="type-signature"></span>nothing<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> nothing explicitly.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect().nothing();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision of the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-        <th>Default</th>
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                </td>
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>precision</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-                <td class="default">
-                
-                    2
-                
-                </td>
-            
-
-            <td class="description last"><p>The number of decimal points to check.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the expected value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The expected value to compare against.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeNegativeInfinity"><span class="type-signature"></span>toBeNegativeInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>-Infinity</code> (-infinity).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeNegativeInfinity();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBePositiveInfinity"><span class="type-signature"></span>toBePositiveInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>Infinity</code> (infinity).</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBePositiveInfinity();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The value to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(array).toContain(anElement);
+    <nav>
+        <h2><a href="index.html">Home</a></h2>
+        <h3>Classes</h3>
+        <ul>
+            <li><a href="Clock.html">Clock</a></li>
+            <li><a href="Env.html">Env</a></li>
+            <li><a href="jsApiReporter.html">jsApiReporter</a></li>
+            <li><a href="Spy.html">Spy</a></li>
+        </ul>
+        <h3>Namespaces</h3>
+        <ul>
+            <li><a href="jasmine.html">jasmine</a></li>
+            <li><a href="matchers.html">matchers</a></li>
+            <li><a href="Spy_and.html">Spy#and</a></li>
+            <li><a href="Spy_calls.html">Spy#calls</a></li>
+        </ul>
+        <h3>Interfaces</h3>
+        <ul>
+            <li><a href="Reporter.html">Reporter</a></li>
+        </ul>
+        <h3>Global</h3>
+        <ul>
+            <li><a href="global.html#afterAll">afterAll</a></li>
+            <li><a href="global.html#afterEach">afterEach</a></li>
+            <li><a href="global.html#beforeAll">beforeAll</a></li>
+            <li><a href="global.html#beforeEach">beforeEach</a></li>
+            <li><a href="global.html#describe">describe</a></li>
+            <li><a href="global.html#expect">expect</a></li>
+            <li><a href="global.html#fail">fail</a></li>
+            <li><a href="global.html#fdescribe">fdescribe</a></li>
+            <li><a href="global.html#fit">fit</a></li>
+            <li><a href="global.html#it">it</a></li>
+            <li><a href="global.html#pending">pending</a></li>
+            <li><a href="global.html#spyOn">spyOn</a></li>
+            <li><a href="global.html#spyOnProperty">spyOnProperty</a></li>
+            <li><a href="global.html#xdescribe">xdescribe</a></li>
+            <li><a href="global.html#xit">xit</a></li>
+        </ul>
+    </nav>
+    <div class="docs">
+        <h1 class="page-title">Namespace: matchers</h1>
+        <section>
+            <header>
+                <h2>matchers</h2>
+            </header>
+            <article>
+                <div class="container-overview">
+                    <div class="description">
+                        <p>Matchers that come with Jasmine out of the box.</p>
+                    </div>
+                </div>
+                <h3 class="subsection-title">Table of Contents</h3>
+                <ul>
+                    <li><a href="#nothing">nothing</a></li>
+                    <li><a href="#toBe">toBe</a></li>
+                    <li><a href="#toBeCloseTo">toBeCloseTo</a></li>
+                    <li><a href="#toBeDefined">toBeDefined</a></li>
+                    <li><a href="#toBeFalsy">toBeFalsy</a></li>
+                    <li><a href="#toBeGreaterThan">toBeGreaterThan</a></li>
+                    <li><a href="#toBeGreaterThanOrEqual">toBeGreaterThanOrEqual</a></li>
+                    <li><a href="#toBeLessThan">toBeLessThan</a></li>
+                    <li><a href="#toBeLessThanOrEqual">toBeLessThanOrEqual</a></li>
+                    <li><a href="#toBeNaN">toBeNaN</a></li>
+                    <li><a href="#toBeNegativeInfinity">toBeNegativeInfinity</a></li>
+                    <li><a href="#toBeNull">toBeNull</a></li>
+                    <li><a href="#toBePositiveInfinity">toBePositiveInfinity</a></li>
+                    <li><a href="#toBeTruthy">toBeTruthy</a></li>
+                    <li><a href="#toBeUndefined">toBeUndefined</a></li>
+                    <li><a href="#toContain">toContain</a></li>
+                    <li><a href="#toEqual">toEqual</a></li>
+                    <li><a href="#toHaveBeenCalled">toHaveBeenCalled</a></li>
+                    <li><a href="#toHaveBeenCalledBefore">toHaveBeenCalledBefore</a></li>
+                    <li><a href="#toHaveBeenCalledTimes">toHaveBeenCalledTimes</a></li>
+                    <li><a href="#toHaveBeenCalledWith">toHaveBeenCalledWith</a></li>
+                    <li><a href="#toMatch">toMatch</a></li>
+                    <li><a href="#toThrow">toThrow</a></li>
+                    <li><a href="#toThrowError">toThrowError</a></li>
+                </ul>
+                <h3 class="subsection-title">Methods</h3>
+                <h4 class="name" id="nothing"><span class="type-signature"></span>nothing<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> nothing explicitly.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect().nothing();</code></pre>
+                <h4 class="name" id="toBe"><span class="type-signature"></span>toBe<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>===</code> to the expected
+                        value.
+                    </p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBe(realThing);</code></pre>
+                <h4 class="name" id="toBeCloseTo"><span class="type-signature"></span>toBeCloseTo<span class="signature">(expected, precision<span class="signature-attributes">opt</span>)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be within a specified precision
+                        of the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th>Default</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                            </td>
+                            <td class="default">
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="name"><code>precision</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="default">
+                                2
+                            </td>
+                            <td class="description last">
+                                <p>The number of decimal points to check.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(number).toBeCloseTo(42.2, 3);</code></pre>
+                <h4 class="name" id="toBeDefined"><span class="type-signature"></span>toBeDefined<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be defined. (Not <code>undefined</code>)</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeDefined();</code></pre>
+                <h4 class="name" id="toBeFalsy"><span class="type-signature"></span>toBeFalsy<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be falsy</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeFalsy();</code></pre>
+                <h4 class="name" id="toBeGreaterThan"><span class="type-signature"></span>toBeGreaterThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than the expected
+                        value.
+                    </p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeGreaterThan(3);</code></pre>
+                <h4 class="name" id="toBeGreaterThanOrEqual"><span class="type-signature"></span>toBeGreaterThanOrEqual<span class="signature">(expected)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be greater than or equal to
+                        the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeGreaterThanOrEqual(25);</code></pre>
+                <h4 class="name" id="toBeLessThan"><span class="type-signature"></span>toBeLessThan<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than the expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeLessThan(0);</code></pre>
+                <h4 class="name" id="toBeLessThanOrEqual"><span class="type-signature"></span>toBeLessThanOrEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be less than or equal to the
+                        expected value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The expected value to compare against.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeLessThanOrEqual(123);</code></pre>
+                <h4 class="name" id="toBeNaN"><span class="type-signature"></span>toBeNaN<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>NaN</code> (Not a Number).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeNaN();</code></pre>
+                <h4 class="name" id="toBeNegativeInfinity"><span class="type-signature"></span>toBeNegativeInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>-Infinity</code> (-infinity).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeNegativeInfinity();</code></pre>
+                <h4 class="name" id="toBeNull"><span class="type-signature"></span>toBeNull<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>null</code>.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeNull();</code></pre>
+                <h4 class="name" id="toBePositiveInfinity"><span class="type-signature"></span>toBePositiveInfinity<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>Infinity</code> (infinity).</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBePositiveInfinity();</code></pre>
+                <h4 class="name" id="toBeTruthy"><span class="type-signature"></span>toBeTruthy<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be truthy.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(thing).toBeTruthy();</code></pre>
+                <h4 class="name" id="toBeUndefined"><span class="type-signature"></span>toBeUndefined<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be <code>undefined</code>.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(result).toBeUndefined():</code></pre>
+                <h4 class="name" id="toContain"><span class="type-signature"></span>toContain<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to contain a specific value.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>The value to look for.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(array).toContain(anElement);
 expect(string).toContain(substring);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using deep equality comparison.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Expected value</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
+                <h4 class="name" id="toEqual"><span class="type-signature"></span>toEqual<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to be equal to the expected, using
+                        deep equality comparison.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="description last">
+                                <p>Expected value</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(bigObject).toEqual({"foo": ['bar', 'baz']});</code></pre>
+                <h4 class="name" id="toHaveBeenCalled"><span class="type-signature"></span>toHaveBeenCalled<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called.</p>
+                </div>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalled();
 expect(mySpy).not.toHaveBeenCalled();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>) to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><a href="Spy.html">Spy</a></span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code> <a href="Spy.html"><code>Spy</code></a>.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called the specified number of times.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Number</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>The number of invocations to look for.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>) to have been called with particular arguments at least once.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                    &lt;repeatable><br>
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The arguments to look for</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-
-            
-
-            <td class="description last"><p>Value to look for in the string.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
+                <h4 class="name" id="toHaveBeenCalledBefore"><span class="type-signature"></span>toHaveBeenCalledBefore<span class="signature">(expected)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called before another <a href="Spy.html"><code>Spy</code></a>.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type"><a href="Spy.html">Spy</a></span>
+                            </td>
+                            <td class="description last">
+                                <p><a href="Spy.html"><code>Spy</code></a> that should have been called after the <code>actual</code>                                    <a href="Spy.html"><code>Spy</code></a>.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledBefore(otherSpy);</code></pre>
+                <h4 class="name" id="toHaveBeenCalledTimes"><span class="type-signature"></span>toHaveBeenCalledTimes<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called the specified number of times.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Number</span>
+                            </td>
+                            <td class="description last">
+                                <p>The number of invocations to look for.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledTimes(3);</code></pre>
+                <h4 class="name" id="toHaveBeenCalledWith"><span class="type-signature"></span>toHaveBeenCalledWith<span class="signature">()</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual (a <a href="Spy.html"><code>Spy</code></a>)
+                        to have been called with particular arguments at least once.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;repeatable><br>
+                            </td>
+                            <td class="description last">
+                                <p>The arguments to look for</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(mySpy).toHaveBeenCalledWith('foo', 'bar', 2);</code></pre>
+                <h4 class="name" id="toMatch"><span class="type-signature"></span>toMatch<span class="signature">(expected)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> the actual value to match a regular expression</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">RegExp</span> |
+                                <span class="param-type">String</span>
+                            </td>
+                            <td class="description last">
+                                <p>Value to look for in the string.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect("my string").toMatch(/string$/);
 expect("other string").toMatch("her");</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Object</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>Value that should be thrown. If not provided, simply the fact that something was thrown will be checked.</p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
+                <h4 class="name" id="toThrow"><span class="type-signature"></span>toThrow<span class="signature">(expected<span class="signature-attributes">opt</span>)</span>
+                    <span class="type-signature"></span>
+                </h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> something.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Object</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p>Value that should be thrown. If not provided, simply the fact that something was thrown will
+                                    be checked.</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrow('foo');
 expect(function() { return 'stuff'; }).toThrow();</code></pre>
-
-
-
-        
-            
-
-    
-
-    
-    <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>, message<span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
-    
-
-    
-
-
-
-<div class="description">
-    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
-</div>
-
-
-
-
-
-
-
-
-
-    <h5>Parameters:</h5>
-    
-
-<table class="params">
-    <thead>
-    <tr>
-        
-        <th>Name</th>
-        
-
-        <th>Type</th>
-
-        
-        <th>Attributes</th>
-        
-
-        
-
-        <th class="last">Description</th>
-    </tr>
-    </thead>
-
-    <tbody>
-    
-
-        <tr>
-            
-                <td class="name"><code>expected</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">Error</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p><code>Error</code> constructor the object that was thrown needs to be an instance of. If not provided, <code>Error</code> will be used.</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>message</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type">RegExp</span>
-|
-
-<span class="param-type">String</span>
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-                    &lt;optional><br>
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>The message that should be set on the thrown <code>Error</code></p></td>
-        </tr>
-
-    
-    </tbody>
-</table>
-
-
-
-
-
-
-<dl class="details">
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-</dl>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    <h5>Example</h5>
-    
-    <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
+                <h4 class="name" id="toThrowError"><span class="type-signature"></span>toThrowError<span class="signature">(expected<span class="signature-attributes">opt</span>,
+                    message
+                    <span class="signature-attributes">opt</span>)</span><span class="type-signature"></span></h4>
+                <div class="description">
+                    <p><a href="global.html#expect"><code>expect</code></a> a function to <code>throw</code> an <code>Error</code>.</p>
+                </div>
+                <h5>Parameters:</h5>
+                <table class="params">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Attributes</th>
+                            <th class="last">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="name"><code>expected</code></td>
+                            <td class="type">
+                                <span class="param-type">Error</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p><code>Error</code> constructor the object that was thrown needs to be an instance of. If
+                                    not provided, <code>Error</code> will be used.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="name"><code>message</code></td>
+                            <td class="type">
+                                <span class="param-type">RegExp</span> |
+                                <span class="param-type">String</span>
+                            </td>
+                            <td class="attributes">
+                                &lt;optional><br>
+                            </td>
+                            <td class="description last">
+                                <p>The message that should be set on the thrown <code>Error</code></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <h5>Example</h5>
+                <pre class="prettyprint"><code>expect(function() { return 'things'; }).toThrowError(MyCustomError, 'message');
 expect(function() { return 'things'; }).toThrowError(MyCustomError, /bar/);
 expect(function() { return 'stuff'; }).toThrowError(MyCustomError);
 expect(function() { return 'other'; }).toThrowError(/foo/);
 expect(function() { return 'other'; }).toThrowError();</code></pre>
-
-
-
-        
-    
-
-    
-
-    
-</article>
-
-</section>
-
-
-
-
-  </div>
-
-  <footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.4</a> on Thu Aug 24 2017 12:23:17 GMT-0700 (PDT)
-  </footer>
+            </article>
+        </section>
+    </div>
+    <footer>
+        Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.4</a> on Thu Aug 24 2017 12:23:17
+        GMT-0700 (PDT)
+    </footer>
 </div>

--- a/css/_scss/api-docs.scss
+++ b/css/_scss/api-docs.scss
@@ -20,23 +20,32 @@
     margin: 0 0 10px 0;
   }
 
+  h3.subsection-title {
+    margin: 2em 0.5em;
+  }
+
   h4 {
     font-size: 18px;
     font-weight: 700;
-    margin: 0 0 10px 0;
+    margin: 2em 0 0.5em;
   }
 
   h5 {
     font-size: 16px;
     font-weight: 700;
-    margin: 0 0 10px 0;
+    margin: 0.5em 0;
   }
 
   em {
     font-style: italic;
   }
 
-  code, tt, kdb, samp, .name, .signature {
+  code,
+  tt,
+  kdb,
+  samp,
+  .name,
+  .signature {
     font-family: Consolas, Monaco, monospace;
   }
 
@@ -47,7 +56,7 @@
   }
 
   .description {
-    margin: 1em 0;
+    margin: 0.75em 0;
   }
 
   .type-signature {
@@ -76,7 +85,7 @@
     margin-bottom: 40px;
 
     &:after {
-      content: '';
+      content: "";
       display: block;
       clear: both;
     }
@@ -93,7 +102,7 @@
 
   .details {
     margin-top: 14px;
-    border-left: 2px solid #DDD;
+    border-left: 2px solid #ddd;
 
     dt {
       padding-left: 10px;
@@ -126,12 +135,12 @@
     margin: 10px 0;
   }
 
-
   thead tr {
     background-color: #ddd;
   }
 
-  td, th {
+  td,
+  th {
     border: 1px solid #ddd;
     margin: 0;
     text-align: left;


### PR DESCRIPTION
# Description
The typesetting on the matchers page made it very hard to both scan and look up matchers as examples were very tightly spaced with the next matcher. As you can see in the screenshots below, the Example stands out as much as the name of the matcher, but doesn't look like it belongs with its matcher. I actually think the H4s with the matcher names could use even more contrast, but I was hesitant to make too many changes since I could not get bundler to actually run.

Additionally, these pages had enormous amounts of extra lines, and indentation followed no pattern, which made the files themselves hard to scan, so that's been cleaned up as well, and what accounts for the majority of the deletions. 

Since this fixes the spacing on H3, H4, and H5 headers, the empty `<div class="details">` nodes were removed, as there appeared to be no use for them other than to add whitespace in weird places.

### Before
![matchers-before](https://user-images.githubusercontent.com/2855641/32243840-feed3a9e-be4c-11e7-9157-f86b34bfab8f.png)

### After
![matchers-after](https://user-images.githubusercontent.com/2855641/32243852-09de0fc8-be4d-11e7-8c59-92b6833bfdf3.png)

### Table of Contents
![matchers-toc](https://user-images.githubusercontent.com/2855641/32244129-eafd7f5c-be4d-11e7-8f55-8ac0e1182202.png)
