### PR TITLE
Fixed syntax error

### DIFF
--- a/setup/nodejs.md
+++ b/setup/nodejs.md
@@ -69,10 +69,10 @@ Helpers are executed before specs. For any example of some helpers see the [reac
   ],
 
   // Stop execution of a spec after the first expectation failure in it
-  stopSpecOnExpectationFailure: false,
+  "stopSpecOnExpectationFailure": false,
 
   // Run specs in semi-random order
-  random: false
+  "random": false
 }
 ```
 


### PR DESCRIPTION
When I copied and pasted that code into my repo, it told me that there must be double quotes around the key. I verified that worked, so now I want to fix the documentation.