### PR TITLE
Lightweight CSS tweaks for article pages

### DIFF
--- a/css/_scss/article.scss
+++ b/css/_scss/article.scss
@@ -1,4 +1,7 @@
 .article {
+  font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+  line-height: 1.2em;
+
   p {
     width: 100%;
     margin: 5px 0;
@@ -13,11 +16,20 @@
     margin: 15px 0;
 
     .highlight {
+      border-radius: 4px;
+      margin-left: 6px;
+      margin-right: 6px;
       padding: 8px;
     }
   }
 
-  pre.highlight, code.highlighter-rouge {
-    font-family: Monaco,Consolas,"Lucida Console",monospace;
+  pre.highlight {
+    font-family: Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  }
+
+  code.highlighter-rouge {
+    background-color: #f0f0f0;
+    font-family: Consolas,"Liberation Mono",Menlo,Courier,monospace;
+    padding: 1px 2px;
   }
 }

--- a/css/_scss/getting_started.scss
+++ b/css/_scss/getting_started.scss
@@ -20,6 +20,7 @@
     font-family: Monaco, Consolas, "Lucida Console", monospace;
     font-size: 12px;
     background-color: #031317;
+    border-radius: 4px;
     color: #93a1a1;
     padding: 10px;
     margin-bottom: 1rem;

--- a/css/_scss/reset.scss
+++ b/css/_scss/reset.scss
@@ -41,3 +41,6 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
+em {
+    font-style: italic;
+}


### PR DESCRIPTION
### SUMMARY

A small bundle of CSS improvements (imo) for article pages.

You can [preview this change live](https://elliot-nelson.github.io/jasmine.github.io/setup/python.html), if you want to browse around and compare to existing site.

### DETAILS

Suggested changes:

- For all articles, increase line height by 20% to remove the "cramped" feeling that paragraphs of text and code snippets have on articles + tutorial pages.

- For code snippets, add a small rounded border and inset 6px from left & right, for a slightly more modern feeling for the alternating paragraphs + code snippets.

- For inline snippet (backquote) text, add the traditional light gray background plus a very small padding, so that file names and commands stand out in more in paragraphs of text.

- I noticed that when writing articles in markdown, emphasis (`_underscore_`) is being ignored, so I included a fix for the `<em>` tag.

- Font updates.  I really like documentation written using the [Cayman theme](https://github.com/pietromenna/jekyll-cayman-theme), which is already pretty close to the font list jasmine is using; I'm proposing:
  - For paragraph text, prefer the Helvetica series (Open Sans, Helvetica Neue, Helvetica, Arial).
  - For code, drop Monaco and Lucida, and prefer Consolas -> Menlo -> Courier.

Some of this is personal preference of course, so I can always cut some of these changes out.

### BEFORE SCREENSHOT

![screencapture-jasmine-github-io-setup-python-html-2019-05-30-09_15_43](https://user-images.githubusercontent.com/58273/58635770-b4c85080-82bc-11e9-908b-bd309a863ba2.png)

### AFTER SCREENSHOT

![screencapture-localhost-4000-setup-python-html-2019-05-30-09_16_08](https://user-images.githubusercontent.com/58273/58635782-b98d0480-82bc-11e9-8ab3-a0b612b29bf7.png)
