### PR TITLE
Strawman: basic version support for articles

### DIFF
--- a/_includes/supported_versions.html
+++ b/_includes/supported_versions.html
@@ -1,0 +1,17 @@
+{% if page.version -%}
+<div class="supported-versions">
+  <h2>Version</h2>
+  {% if page.version.added -%}
+  <p>Added in Jasmine <a href="https://github.com/jasmine/jasmine/releases/tag/v{{page.version.added}}">v{{page.version.added}}</a>
+  {% endif -%}
+  {% if page.version.updated -%}
+  <p>Updated in Jasmine <a href="https://github.com/jasmine/jasmine/releases/tag/v{{page.version.updated}}">v{{page.version.updated}}</a>
+  {% endif -%}
+  {% if page.version.deprecated -%}
+  <p>Deprecated in Jasmine <a href="https://github.com/jasmine/jasmine/releases/tag/v{{page.version.deprecated}}">v{{page.version.deprecated}}</a>
+  {% endif -%}
+  {% if page.version.removed -%}
+  <p>Removed in Jasmine <a href="https://github.com/jasmine/jasmine/releases/tag/v{{page.version.removed}}">v{{page.version.removed}}</a>
+  {% endif -%}
+</div>
+{% endif -%}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -4,4 +4,5 @@ layout: default
 
 <div class="main-content article">
   {{content}}
+  {% include supported_versions.html %}
 </div>

--- a/_tutorials/custom_argument_matchers.md
+++ b/_tutorials/custom_argument_matchers.md
@@ -1,6 +1,9 @@
 ---
 title: Custom argument matchers
 layout: article
+version:
+  added: 1.2.0
+  updated: 2.2.0
 ---
 # Custom argument matchers
 


### PR DESCRIPTION
### SUMMARY

Strawman a way to easily specify what versions are applicable for the tutorial articles.

### DETAILS

- Allow any article to specify some front matter at the top of the file, indicating when the feature being described was _added_, _updated_, _deprecated_, or _removed_.

- If any/all of the version tags exist, auto-include a small section at the bottom with links to the relevant release (which, for newer releases, also is a spot to see release notes).

This is just a starting point for discussion.  The example here is the asymmetric matcher tutorial; it lists v1.2.0 (when support for objects with custom jasmineMatches functions were first introduced) and v2.2.0 (the version this article is relevant to, with the asymmetricMatch function).

Ideally, I'd rather have whole old copies of articles so that you could navigate back to (for example) "how to create a custom Matcher in v1.3.0" vs "how to create a custom Matcher in v3.4.0".  But maybe this is a stepping stone?

### SCREENSHOT

<img width="1033" alt="Screen Shot 2019-06-12 at 11 33 24 AM" src="https://user-images.githubusercontent.com/58273/59365635-dc7cd700-8d06-11e9-87fc-091835e898b3.png">
