### PR TITLE
Docs: Consistent Helpers Examples

### DIFF
--- a/_tutorials/react_with_npm.md
+++ b/_tutorials/react_with_npm.md
@@ -72,8 +72,8 @@ In order to ensure these files are loaded first, we'll edit `spec/support/jasmin
 
 ```json
 "helpers": [
-  "helpers/babel.js",
-  "helpers/**/*.js"
+  "../spec/helpers/babel.js",
+  "../spec/helpers/**/*.js"
 ],
 ```
 
@@ -81,8 +81,8 @@ Or, if using Typescript:
 
 ```json
 "helpers": [
-  "helpers/babel.js",
-  "helpers/**/*.{js,ts}"
+  "../spec/helpers/babel.js",
+  "../spec/helpers/**/*.{js,ts}"
 ],
 ```
 


### PR DESCRIPTION
The react_with_npm doc has conflicting examples for helpers, and this PR makes them all the same:
```
"helpers/babel.js",
"helpers/**/*.js"
```

And this in the other:
```
"../spec/helpers/babel.js",
"../spec/helpers/**/*.js"
```

