### PR TITLE
Document additional configuration options available when running with NodeJS

### DIFF
--- a/setup/nodejs.md
+++ b/setup/nodejs.md
@@ -68,8 +68,14 @@ Helpers are executed before specs. For an example of some helpers see the [react
     "helpers/**/*.js"
   ],
 
+  // Whether to fail a spec that ran no expectations
+  "failSpecWithNoExpectations": false,
+
   // Stop execution of a spec after the first expectation failure in it
   "stopSpecOnExpectationFailure": false,
+
+  // Stop execution of the suite after the first spec failure  
+  "stopOnSpecFailure": false,
 
   // Run specs in semi-random order
   "random": false
@@ -154,7 +160,7 @@ var Jasmine = require('jasmine');
 var jasmine = new Jasmine();
 ```
 
-### Load configuration from a file or from an object.
+### Load configuration from a file or from an object
 
 ```javascript
 jasmine.loadConfigFile('spec/support/jasmine.json');


### PR DESCRIPTION
Documents two config options, one already in 3.5, one pending merge in jasmine-npm repo, see https://github.com/jasmine/jasmine-npm/issues/156