### PR TITLE
Use npx in instructions and make clear that global install is optional.

### DIFF
--- a/pages/getting_started.html
+++ b/pages/getting_started.html
@@ -65,7 +65,7 @@ title: Getting Started
     <p>Add Jasmine to your package.json</p>
     <pre>npm install --save-dev jasmine</pre>
     <p>Initialize Jasmine in your project</p>
-    <pre>node node_modules/jasmine/bin/jasmine init</pre>
+    <pre>npx jasmine init</pre>
     <p>Set jasmine as your test script in your package.json</p>
     <pre>"scripts": { "test": "jasmine" }</pre>
     <p>Run your tests</p>

--- a/setup/nodejs.md
+++ b/setup/nodejs.md
@@ -29,7 +29,7 @@ jasmine init
 Note that if you installed Jasmine locally you could still use the command line like this:
 
 ```sh
-node node_modules/jasmine/bin/jasmine init
+npx jasmine init
 ```
 
 ## Generate examples
@@ -78,7 +78,7 @@ Helpers are executed before specs. For an example of some helpers see the [react
 
 ## Running tests
 
-Once you have set up your `jasmine.json`, you can execute all your specs by running `jasmine` from the root of your project (or `node node_modules/jasmine/bin/jasmine.js` if you had installed it locally).
+Once you have set up your `jasmine.json`, you can execute all your specs by running `jasmine` from the root of your project (or `npx jasmine` if you had installed it locally).
 
 If you want to just run one spec or only those whom file names match a certain [glob](https://github.com/isaacs/node-glob) pattern you can do it like this:
 

--- a/setup/nodejs.md
+++ b/setup/nodejs.md
@@ -10,11 +10,17 @@ The Jasmine node package contains helper code for developing and running Jasmine
 
 ## Install
 
-You can install Jasmine using npm, locally in your project and globally to use the CLI tool.
+You can install Jasmine using npm locally in your project:
 
 ```sh
-npm install jasmine
+npm install --save-dev jasmine
+```
 
+With the above local installation you can invoke the CLI tool using `npx jasmine ...` commands.
+
+Optionally you can also install jasmine globally so that you can invoke the CLI tool using `jasmine ...` commands.
+
+```sh
 npm install -g jasmine
 ```
 
@@ -26,7 +32,7 @@ Initialize a project for Jasmine by creating a spec directory and configuration 
 jasmine init
 ```
 
-Note that if you installed Jasmine locally you could still use the command line like this:
+Note that if you installed Jasmine locally use `npx jasmine` instead of `jasmine` in any of these examples, like so:
 
 ```sh
 npx jasmine init


### PR DESCRIPTION
The npx command has been available since npm  version 5.2, released July 2017), so I think it'st now reasonable to assume people have it in their Node installation.

Demo of this PR:
https://eobrain.github.io/jasmine.github.io/pages/getting_started.html
https://eobrain.github.io/jasmine.github.io/setup/nodejs.html
