### PR TITLE
Fix invalid code in callback tutorial

### DIFF
--- a/_tutorials/async.md
+++ b/_tutorials/async.md
@@ -68,7 +68,7 @@ beforeEach(function(done) {
 
 
 it('does a thing', function(done) {
-  someAsyncFunction(result) {
+  someAsyncFunction(function(result) {
     expect(result).toEqual(someExpectedValue);
     done();
   });


### PR DESCRIPTION
Fixed a simple syntax error in the callback part of async tutorial.