### PR TITLE
Fixed wrong npm package name

### DIFF
--- a/pages/getting_started.html
+++ b/pages/getting_started.html
@@ -30,7 +30,7 @@ title: Getting Started
     <p>Add Jasmine to your package.json</p>
     <pre>npm install --save-dev jasmine-browser-runner</pre>
     <p>Initialize Jasmine in your project</p>
-    <pre>npx jasmine-browser init</pre>
+    <pre>npx jasmine-browser-runner init</pre>
     <p>Set jasmine as your test script in your package.json</p>
     <pre>"scripts": { "test": "jasmine-browser-runner runSpecs" }</pre>
     <p>Run your tests</p>


### PR DESCRIPTION
The package name jasmine-browser is wrong in the `npx` command which lead to https://github.com/jasmine/jasmine-browser/issues/6

This is now fixed to the correct package name: jasmine-browser-runner