### PR TITLE
Fix outdated matchersUtil.js url

### DIFF
--- a/_versions/2.0/custom_matcher.html
+++ b/_versions/2.0/custom_matcher.html
@@ -85,7 +85,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.0/src/custom_matcher.js
+++ b/_versions/2.0/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.1/custom_matcher.html
+++ b/_versions/2.1/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.1/src/custom_matcher.js
+++ b/_versions/2.1/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.2/custom_matcher.html
+++ b/_versions/2.2/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.2/src/custom_matcher.js
+++ b/_versions/2.2/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.3/custom_matcher.html
+++ b/_versions/2.3/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.3/src/custom_matcher.js
+++ b/_versions/2.3/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.4/custom_matcher.html
+++ b/_versions/2.4/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.4/src/custom_matcher.js
+++ b/_versions/2.4/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.5/custom_matcher.html
+++ b/_versions/2.5/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.5/src/custom_matcher.js
+++ b/_versions/2.5/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.6/custom_matcher.html
+++ b/_versions/2.6/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.6/src/custom_matcher.js
+++ b/_versions/2.6/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.7/custom_matcher.html
+++ b/_versions/2.7/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.7/src/custom_matcher.js
+++ b/_versions/2.7/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.8/custom_matcher.html
+++ b/_versions/2.8/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.8/src/custom_matcher.js
+++ b/_versions/2.8/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**

--- a/_versions/2.9/custom_matcher.html
+++ b/_versions/2.9/custom_matcher.html
@@ -88,7 +88,7 @@
         </div>
         <h2>Matcher Factories</h2>
 
-<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
+<p>Custom matcher factories are passed two parameters: <code>util</code>, which has a set of utility functions for matchers to use (see: <a href="https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js"><code>matchersUtil.js</code></a> for the current list) and <code>customEqualityTesters</code> which needs to be passed in if <code>util.equals</code> is ever called. These parameters are available for use when the matcher is called.</p>
       </td>
       <td class="code">
         <div class="highlight">

--- a/_versions/2.9/src/custom_matcher.js
+++ b/_versions/2.9/src/custom_matcher.js
@@ -16,7 +16,7 @@ var customMatchers = {
    *
    * Custom matcher factories are passed two parameters: `util`, which has a set of utility functions for matchers to use (see: [`matchersUtil.js`][mu.js] for the current list) and `customEqualityTesters` which needs to be passed in if `util.equals` is ever called. These parameters are available for use when the matcher is called.
    *
-   * [mu.js]: https://github.com/pivotal/jasmine/blob/master/src/core/matchers/matchersUtil.js
+   * [mu.js]: https://github.com/jasmine/jasmine/blob/main/src/core/matchers/matchersUtil.js
    */
   toBeGoofy: function(util, customEqualityTesters) {
     /**


### PR DESCRIPTION
Hey,

I've found that the original page returns 404, so there is a small update.