### PR TITLE
Update Node.JS version support info

### DIFF
--- a/setup/nodejs.md
+++ b/setup/nodejs.md
@@ -7,8 +7,8 @@ redirect_from: /edge/node.html
 # Using Jasmine with Node
 
 The `jasmine` module is a command line interface and supporting code for running
-Jasmine specs under Node.js. Jasmine 4.x supports Node versions 12.17+, 14,
-and 16. (Odd-numbered Node versions aren't supported, but many of them work.)
+Jasmine specs under Node.js. Jasmine 5.x supports Node versions 18, 20,
+and 22. (Odd-numbered Node versions aren't supported, but many of them work.)
 
 ## Install
 


### PR DESCRIPTION
Updating the version support info to match the [Jasmine README](https://github.com/jasmine/jasmine?tab=readme-ov-file#supported-environments).

Not sure if other things need updating. At a glance, nothing from the [4 to 5 upgrade guide](https://jasmine.github.io/upgrade-guides/5.0) _seems_ to affect any info given in this setup guide.