### PR TITLE
Fix broken link references in the docs

### DIFF
--- a/_tutorials/custom_matchers.md
+++ b/_tutorials/custom_matchers.md
@@ -55,8 +55,8 @@ set of utility functions for matchers to use to perform tasks like
 determining whether two objects are equal (see:
 <a href="/api/edge/MatchersUtil.html"><code>MatchersUtil</code></a> for reference documentation).
 By using <code>MatchersUtil</code> where appropriate, custom matchers can work with
-<a href="http://localhost:4000/tutorials/custom_equality">custom equality testers</a>
-and <a href="http://localhost:4000/tutorials/custom_object_formatters">custom object formatters</a>
+<a href="/tutorials/custom_equality">custom equality testers</a>
+and <a href="/tutorials/custom_object_formatters">custom object formatters</a>
 without any extra effort.</p>
 
       </div>

--- a/_tutorials/src/custom_matchers.js
+++ b/_tutorials/src/custom_matchers.js
@@ -22,8 +22,8 @@ const customMatchers = {
      determining whether two objects are equal (see:
      [`MatchersUtil`](/api/edge/MatchersUtil.html) for reference documentation).
      By using `MatchersUtil` where appropriate, custom matchers can work with
-     [custom equality testers](http://localhost:4000/tutorials/custom_equality)
-     and [custom object formatters](http://localhost:4000/tutorials/custom_object_formatters)
+     [custom equality testers](/tutorials/custom_equality)
+     and [custom object formatters](/tutorials/custom_object_formatters)
      without any extra effort.
      */
     toBeGoofy: function (matchersUtil) {

--- a/_upgrade-guides/5.0.md
+++ b/_upgrade-guides/5.0.md
@@ -30,7 +30,7 @@ to 2.0.
 The new parallel execution mode introduced in Jasmine 5.0 comes with additional
 restrictions on how both specs and reporters are written. These restrictions
 apply only when Jasmine is run in the parallel mode. See the
-[guide to parallel execution](running_specs_in_parallel) for details.
+[guide to parallel execution](/tutorials/running_specs_in_parallel) for details.
 
 <h2>Contents</h2>
 
@@ -85,7 +85,7 @@ or `jasmine-browser-runner` 2.x.
 The biggest change in 5.0 is support for parallel execution in Node.js via the
 `jasmine` package. Parallel execution imposes some constraints on both test
 suites and reporters, and as a result not everyone will be able to adopt it
-without making changes. See [Running Specs in Parallel](running_specs_in_parallel)
+without making changes. See [Running Specs in Parallel](/tutorials/running_specs_in_parallel)
 for more information.
 
 <h2>Changes to global error handling in browsers</h2>
@@ -96,7 +96,7 @@ use `addEventListener` instead. This means that Jasmine will no longer override
 any error handler that your code installs prior to startup. It also means that
 you can no longer override Jasmine's global error handling by setting
 `window.onerror`. If you need to override Jasmine's global error handling, use
-[spyOnGlobalErrors](http://localhost:4000/api/4.6/jasmine.html#.spyOnGlobalErrorsAsync).
+[spyOnGlobalErrors](/api/4.6/jasmine.html#.spyOnGlobalErrorsAsync).
 
 Using `addEventListener` allows Jasmine to provide better error information in
 many cases. However, some browsers limit the information that's provided to


### PR DESCRIPTION
Fixed 4 instances of broken links: three with a hardcoded localhost:4000 reference instead of a path relative to the base URL, and one pointing to the wrong path for the "Running specs in parallel" tutorial.

These links lead to 404s within the current production website.